### PR TITLE
make sure deployments don't use a default SECRET_KEY

### DIFF
--- a/.github/workflows/be_test.yml
+++ b/.github/workflows/be_test.yml
@@ -44,6 +44,7 @@ jobs:
       OIDC_RSA_PRIVATE_KEY: "-----BEGIN RSA PRIVATE KEY-----\\Abc123\\n-----END RSA PRIVATE KEY-----"
       PATIENT_AUTHORIZATION_CODE_CHALLENGE: "abc123"
       PATIENT_AUTHORIZATION_CODE_VERIFIER: "abc123"
+      SECRET_KEY: "super-secret-key"
 
     steps:
       - run: echo "Triggered by a ${{ github.event_name }} event."

--- a/README.md
+++ b/README.md
@@ -933,7 +933,8 @@ For deployment options and a comprehensive guide take a look at the official [Dj
 An example Dockerfile is included to deploy the app using [gunicorn](https://gunicorn.org/) and [WhiteNoise](https://whitenoise.readthedocs.io/en/stable/django.html) for static files.
 
 1. Create a new empty Postgres database
-1. Copy `jhe/dot_env_example.txt` to `jhe/.env` and update the `DB_*` parameters from (1)
+1. Copy `jhe/dot_env_example.txt` to `jhe/.env` and update the `DB_*` parameters from (1),
+  and generate a new value for `SECRET_KEY`, e.g. with `openssl rand -base64 32`.
 1. Migrate the DB by running `python manage.py migrate`
 1. Seed the database by running the Django management command `python manage.py seed_db`
 1. From the `jhe` directory, build the image `$ docker build .`

--- a/jhe/dot_env_example.txt
+++ b/jhe/dot_env_example.txt
@@ -4,6 +4,8 @@ REGISTRATION_INVITE_CODE="helloworld"
 SITE_URL="http://localhost:8000"
 DJANGO_LOG_LEVEL="INFO"
 
+SECRET_KEY="django-insecure--l2nzvywecjf!sgu3=v8y#e5@rk-5_l0=0ez!abg576r^th@o"
+
 OIDC_CLIENT_AUTHORITY_PATH="/o/"
 OIDC_CLIENT_REDIRECT_URI_PATH="/auth/callback"
 OIDC_CLIENT_ID="Ima7rx8D6eko0PzlU1jK28WBUT2ZweZj7mqVG2wm"

--- a/jhe/jhe/settings.py
+++ b/jhe/jhe/settings.py
@@ -1,7 +1,10 @@
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path, PosixPath
+from urllib.parse import urlparse
 
+from django.core.management.utils import get_random_secret_key
 from dotenv import load_dotenv
 
 JHE_VERSION = "v0.0.7"
@@ -29,20 +32,25 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure--4r1=)&2xj1u&sfj7*$jfzdp@*pyr*^n4l*n1p^inne@ulzn1f"
+SECRET_KEY = os.getenv("SECRET_KEY")
+if SECRET_KEY is None:
+    logging.warning(
+        "SECRET_KEY unset, using a randomly generated SECRET_KEY; this will not work with more than one worker."
+    )
+    SECRET_KEY = get_random_secret_key()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
 SITE_TITLE = os.getenv("SITE_TITLE", "")
-SITE_URL = os.getenv("SITE_URL", "")
+SITE_URL = os.getenv("SITE_URL", "http://localhost:8000")
 CH_INVITATION_LINK_PREFIX = os.getenv("CH_INVITATION_LINK_PREFIX", "")
 CH_INVITATION_LINK_EXCLUDE_HOST = os.getenv("CH_INVITATION_LINK_EXCLUDE_HOST", "")
 OIDC_CLIENT_AUTHORITY = SITE_URL + os.getenv("OIDC_CLIENT_AUTHORITY_PATH", "")
 OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID", "")  # TBD: Multi-tenancy lookup based on client entry URI
 OIDC_CLIENT_REDIRECT_URI = SITE_URL + os.getenv("OIDC_CLIENT_REDIRECT_URI_PATH", "")
 
-ALLOWED_HOSTS = [[i for i in SITE_URL.split("/") if i][-1].split(":")[0]]
+ALLOWED_HOSTS = [urlparse(SITE_URL).hostname]
 
 CSRF_TRUSTED_ORIGINS = [SITE_URL]
 

--- a/jhe/jhe/settings.py
+++ b/jhe/jhe/settings.py
@@ -34,13 +34,13 @@ SECRET_KEY = "django-insecure--4r1=)&2xj1u&sfj7*$jfzdp@*pyr*^n4l*n1p^inne@ulzn1f
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-SITE_TITLE = os.getenv("SITE_TITLE")
-SITE_URL = os.getenv("SITE_URL")
-CH_INVITATION_LINK_PREFIX = os.getenv("CH_INVITATION_LINK_PREFIX")
-CH_INVITATION_LINK_EXCLUDE_HOST = os.getenv("CH_INVITATION_LINK_EXCLUDE_HOST")
-OIDC_CLIENT_AUTHORITY = SITE_URL + os.getenv("OIDC_CLIENT_AUTHORITY_PATH")
-OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID")  # TBD: Multi-tenancy lookup based on client entry URI
-OIDC_CLIENT_REDIRECT_URI = SITE_URL + os.getenv("OIDC_CLIENT_REDIRECT_URI_PATH")
+SITE_TITLE = os.getenv("SITE_TITLE", "")
+SITE_URL = os.getenv("SITE_URL", "")
+CH_INVITATION_LINK_PREFIX = os.getenv("CH_INVITATION_LINK_PREFIX", "")
+CH_INVITATION_LINK_EXCLUDE_HOST = os.getenv("CH_INVITATION_LINK_EXCLUDE_HOST", "")
+OIDC_CLIENT_AUTHORITY = SITE_URL + os.getenv("OIDC_CLIENT_AUTHORITY_PATH", "")
+OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID", "")  # TBD: Multi-tenancy lookup based on client entry URI
+OIDC_CLIENT_REDIRECT_URI = SITE_URL + os.getenv("OIDC_CLIENT_REDIRECT_URI_PATH", "")
 
 ALLOWED_HOSTS = [[i for i in SITE_URL.split("/") if i][-1].split(":")[0]]
 


### PR DESCRIPTION
this avoids anyone deploying JHE with the default secret.

It also ensures the type is correct for missing environment fields, using empty strings instead of None, which lead to errors when running e.g. `manage.py ` steps without .env, such as `collectstatic` during docker build.

closes #176