### PR TITLE
fix typo in header-1.0 metadata schema

### DIFF
--- a/data/omh/json-schemas/metadata/header-1.0.json
+++ b/data/omh/json-schemas/metadata/header-1.0.json
@@ -36,11 +36,11 @@
             "$ref": "#/definitions/date_time"
         },
         "modality": {
-            "description": "The modality whereby the measure is obtained, e.g., sensed or sensed",
+            "description": "The modality whereby the measure is obtained, e.g., sensed or self-reported",
             "type": "string",
             "enum": [
                 "sensed",
-                "sensed"
+                "self-reported"
             ]
         },
         "acquisition_rate": {


### PR DESCRIPTION
no hand-edits, just downloaded https://opensource.ieee.org/omh/1752-2/-/blob/1.1-metabolic/schemas/metadata/header-1.0.json

needed to add `self-reported` data