### PR TITLE
increase hard limit on paginated queries to 10k

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -652,7 +652,13 @@ class Patient(models.Model):
 
         # Set default values for pagination parameters
         offset = 0 if offset is None else int(offset)
-        limit = 1000 if page is None else int(page)
+        # FIXME: these are not actually used for pagination!
+        # they set the unconditional boundaries on multi-page queries
+        if page is not None:
+            raise NotImplementedError("page not supported")
+        # since this is unconditional, set it pretty high,
+        # otherwise fetching more data than this is impossible
+        limit = 10_000
 
         # TBD: Query optimization: https://stackoverflow.com/a/6037376
         # TBD: sub constants from config
@@ -1239,7 +1245,13 @@ class Observation(models.Model):
 
         # Set default values for pagination parameters
         offset = 0 if offset is None else int(offset)
-        limit = 1000 if page is None else int(page)
+        # FIXME: these are not actually used for pagination!
+        # they set the unconditional boundaries on multi-page queries
+        if page is not None:
+            raise NotImplementedError("page not supported")
+        # since this is unconditional, set it pretty high,
+        # otherwise fetching more data than this is impossible
+        limit = 10_000
 
         print(f"jhe_user_id: {jhe_user_id}")
         if not patient_id:


### PR DESCRIPTION
I think this _should_ be removed altogether (#204), but I'm not comfortable doing that right now.

Despite comments, this limit doesn't set anything about the page, it sets the _total_ limit of the whole paginated query.

I've tested manually that removing these offset and limit arguments (which cannot be set by queries), but it's unclear to me what they are for, and have instead opted to just increase the limit to a level that doesn't prevent things from working in the immediate term (we need queries with thousands of results).

I elected to raise an error if page is not None, because the previous definition of `limit = int(page)` was clearly incorrect, so an error would be better if that branch could ever be taken (it cannot, currently).