### PR TITLE
docs: updated cross-environment debug config

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ OIDC_CLIENT_AUTHORITY = 'http://localhost:8000/o/'
 
 By hardcoding the values you prevent the path injection and keep the SPA from seeing broken URLs, which resolves the blank screen after login on Windows hosts.
 
+## Remote debugging tips
+
+1. **Control log verbosity** with DJANGO_LOG_LEVEL – The backend now reads the `DJANGO_LOG_LEVEL` environment variable (default: INFO) for both the root logger and the django logger. For `Fly.io` deployments, set `DJANGO_LOG_LEVEL=DEBUG` in `fly.toml` and run `fly deploy`. For local development, set `DJANGO_LOG_LEVEL` using the appropriate environment configuration for your operating system.
+
+2. **Don’t forget the SPA debug banner** – temporarily enabling Django `DEBUG` surfaces server-side tracebacks in the portal so you can correlate HTTP logs with richer context. Turn it off afterward to avoid exposing stack traces.
+
+> **Note:** `DJANGO_LOG_LEVEL` is a configuration flag, not a secret. Keep `fly secrets` and your `.env` strictly for secrets. This keeps local CI environments aligned with the same value.
+
 ## Working with the Web UI
 
 ### Patients & Practitioners

--- a/core/views/patient.py
+++ b/core/views/patient.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 
 from django.conf import settings
@@ -36,8 +35,6 @@ from core.serializers import (
     StudyConsentsSerializer,
     StudyPatientScopeConsentSerializer,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class PatientViewSet(AdminListMixin, ModelViewSet):

--- a/dot_env_example.txt
+++ b/dot_env_example.txt
@@ -2,7 +2,6 @@ SITE_TITLE="JupyterHealth Exchange Dev"
 TIME_ZONE="America/Los_Angeles"
 REGISTRATION_INVITE_CODE="helloworld"
 SITE_URL="http://localhost:8000"
-DJANGO_LOG_LEVEL="INFO"
 
 SECRET_KEY="django-insecure--l2nzvywecjf!sgu3=v8y#e5@rk-5_l0=0ez!abg576r^th@o"
 

--- a/jhe/settings.py
+++ b/jhe/settings.py
@@ -175,6 +175,8 @@ DATABASES = {
 # default django logging scheme: https://docs.djangoproject.com/en/5.2/ref/logging/#default-logging-configuration
 # https://docs.djangoproject.com/en/5.2/topics/logging
 # also see: https://docs.djangoproject.com/en/5.2/howto/error-reporting/#filtering-error-reports
+DEFAULT_LOG_LEVEL = os.getenv("DJANGO_LOG_LEVEL", "INFO").upper()
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -186,13 +188,13 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        # makes it required to set the log level in the environment variable DJANGO_LOG_LEVEL
-        "level": os.getenv("DJANGO_LOG_LEVEL"),
+        # uses the DJANGO_LOG_LEVEL env var (defaults to INFO)
+        "level": DEFAULT_LOG_LEVEL,
     },
     "loggers": {
         "django": {
             "handlers": ["console"],
-            "level": "INFO",
+            "level": DEFAULT_LOG_LEVEL,
             "propagate": False,
         },
     },


### PR DESCRIPTION
* Added remote debugging tips to the README.
* Removed hardcoded `DJANGO_LOG_LEVEL` from `dot_env_example.txt`.
* Updated `settings.py` to use `DJANGO_LOG_LEVEL` from environment variables for logging configuration.