### PR TITLE
feat(seed): replace real institutions with synthetic names, fix obser…

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ flowchart TD
     style sam fill:#CFC
 
     %% berkeley
-    ucb("Organization:<br/>University of California Berkeley") --> ccdss("Organization:<br/>College of Computing, Data Science and Society")
-    ccdss --> bids("Organization:<br/>Berkeley Institute for Data Science (BIDS)")
+    ucb("Organization:<br/>Example University") --> ccdss("Organization:<br/>Example School of Data Science")
+    ccdss --> bids("Organization:<br/>Example Research Institute (ERI)")
 
     %% berkeley users
     ucb --Manager--> mary("ManagerMary<br/><small>mary\@example.com</small>")
@@ -186,27 +186,27 @@ flowchart TD
     style tom fill:#CFC
 
     %% berkeley studies
-    bids --> bidsStudyOnBPHR("BIDS Study on BP & HR<br/><small>Blood Pressure<br/>Heart Rate</small>")
+    bids --> bidsStudyOnBPHR("Example Study on BP & HR<br/><small>Blood Pressure<br/>Heart Rate</small>")
     style bidsStudyOnBPHR fill:#CFF
-    bids --> bidsStudyOnBP("BIDS Study on BP<br/><small>Blood Pressure </small>")
+    bids --> bidsStudyOnBP("Example Study on BP<br/><small>Blood Pressure </small>")
     style bidsStudyOnBP fill:#CFF
 
     %% berkeley patients
-    bids --> peter("BidsPatientPeter<br/><small>peter\@example.com</small>")
+    bids --> peter("EriPatientPeter<br/><small>peter\@example.com</small>")
     style peter fill:#FCC
     peter --Consented--> bidsStudyOnBPHR
     peter --Requested--> bidsStudyOnBP
-    pamela("BidsPatientPamela<br/><small>pamela\@example.com</small>")
+    pamela("EriPatientPamela<br/><small>pamela\@example.com</small>")
     style pamela fill:#FCC
     bids --> pamela
     pamela --Consented--> bidsStudyOnBPHR
     pamela --Consented--> bidsStudyOnBP
 
     %% ucsf
-    ucsf("Organization:<br/>University of California San Francisco") --> med("Organization:<br/>Department of Medicine")
-    med --> cardio("Organization:<br/>Cardiology")
-    cardio --> moslehi("Organization:<br/>Moslehi Lab")
-    cardio --> olgin("Organization:<br/>Olgin Lab")
+    ucsf("Organization:<br/>Example Medical University") --> med("Organization:<br/>Example Department")
+    med --> cardio("Organization:<br/>Heart Research Division")
+    cardio --> moslehi("Organization:<br/>Example Lab Alpha")
+    cardio --> olgin("Organization:<br/>Example Lab Beta")
 
     %% ucsf users
     ucsf --Manager-->mark("ManagerMark<br/><small>mark\@example.com</small>")
@@ -218,21 +218,21 @@ flowchart TD
     olgin --Manager--> tom
 
     %% ucsf studies
-    cardio --> cardioStudyOnRR("Cardio Study on RR<br/><small>Respiratory rate</small>")
+    cardio --> cardioStudyOnRR("Example Study on RR<br/><small>Respiratory rate</small>")
     style cardioStudyOnRR fill:#CFF
-    moslehi --> moslehiStudyOnBT("Moslehi Study on BT<br/><small>Body Temperature</small>")
+    moslehi --> moslehiStudyOnBT("Example Study on BT<br/><small>Body Temperature</small>")
     style moslehiStudyOnBT fill:#CFF
-    olgin --> olginStudyOnO2("Olgin Study on O2<br/><small>Oxygen Saturation</small>")
+    olgin --> olginStudyOnO2("Example Study on O2<br/><small>Oxygen Saturation</small>")
     style olginStudyOnO2 fill:#CFF
 
     %% ucsf patients
-    moslehi --> percy("MoslehiPatientPercy<br/><small>percy\@example.com</small>")
+    moslehi --> percy("AlphaPatientPercy<br/><small>percy\@example.com</small>")
     style percy fill:#FCC
     percy --Consented--> moslehiStudyOnBT
-    olgin --> paul("OlginPatientPaul<br/><small>paul\@example.com</small>")
+    olgin --> paul("BetaPatientPaul<br/><small>paul\@example.com</small>")
     style paul fill:#FCC
     paul --Consented--> olginStudyOnO2
-    cardio --> pat("CardioOlginPatientPat<br/><small>pat\@example.com</small>")
+    cardio --> pat("HeartBetaPatientPat<br/><small>pat\@example.com</small>")
     style pat fill:#FCC
     pat --Consented--> cardioStudyOnRR
     pat --Consented--> olginStudyOnO2
@@ -243,7 +243,7 @@ flowchart TD
 
 - Additional test data from the [iglu project](https://github.com/irinagain/iglu) can be seeded by running the following command (please note this can take 10-20 minutes to run)
   `$ python manage.py iglu`
-- This creates a new study under the "Berkeley Institute for Data Science (BIDS)" Organization with 19 mock patients and 1745 real Observation data points
+- This creates a new study under the "Example Research Institute (ERI)" Organization with 19 mock patients and 1745 real Observation data points
 
 
 ## Working with APIs
@@ -624,14 +624,14 @@ When `DEBUG` is enabled the SPA debug page now summarizes server errors (includi
 ## Test Procedure
 
 1. **Select Parent Organization**
-   Choose **University of California, Berkeley**.
+   Choose **Example University**.
 
 2. **Open Sub-Organization**
-   Click **View** for **Berkeley Institute for Data Science (BIDS)**.
+   Click **View** for **Example Research Institute (ERI)**.
 
 3. **Create a New Study**
 
-   * Under BIDS, create a study.
+   * Under ERI, create a study.
    * Add the **iHealth** data source.
    * Set the data scope to **blood glucose**.
 

--- a/core/management/commands/iglu.py
+++ b/core/management/commands/iglu.py
@@ -209,9 +209,9 @@ class Command(BaseCommand):
             return
 
         # Find an org by name fragment
-        organization = Organization.objects.filter(name__icontains="BIDS").first()
+        organization = Organization.objects.filter(name__icontains="Example Research Institute").first()
         if not organization:
-            self.stderr.write(self.style.ERROR("Missing Organization with name containing 'BIDS'"))
+            self.stderr.write(self.style.ERROR("Missing Organization with name containing 'Example Research Institute'"))
             return
 
         # Data source by name

--- a/core/models.py
+++ b/core/models.py
@@ -980,8 +980,12 @@ class Observation(models.Model):
             )
 
         study_sql_where = ""
+        study_scope_join = ""
+        study_scope_where = ""
         if study_id:
             study_sql_where = "AND core_study.id={study_id}".format(study_id=int(study_id))
+            study_scope_join = "JOIN core_studyscoperequest ON core_studyscoperequest.study_id=core_study.id"
+            study_scope_where = "AND core_observation.codeable_concept_id=core_studyscoperequest.scope_code_id"
 
         patient_id_sql_where = ""
         if patient_id:
@@ -1011,16 +1015,20 @@ class Observation(models.Model):
         JOIN core_practitionerorganization ON core_practitionerorganization.organization_id=core_organization.id
         LEFT JOIN core_studypatient ON core_studypatient.patient_id=core_patient.id
         LEFT JOIN core_study ON core_study.id=core_studypatient.study_id
+        {study_scope_join}
         WHERE core_practitionerorganization.practitioner_id = %(practitioner_id)s
 
         {organization_sql_where}
         {study_sql_where}
+        {study_scope_where}
         {patient_id_sql_where}
         {observation_sql_where}
         ORDER BY core_observation.last_updated DESC
         """.format(
             organization_sql_where=organization_sql_where,
             study_sql_where=study_sql_where,
+            study_scope_join=study_scope_join,
+            study_scope_where=study_scope_where,
             patient_id_sql_where=patient_id_sql_where,
             observation_sql_where=observation_sql_where,
         )
@@ -1060,8 +1068,12 @@ class Observation(models.Model):
 
         # Explicitly cast to ints so no injection vulnerability
         study_sql_where = ""
+        study_scope_join = ""
+        study_scope_where = ""
         if study_id:
             study_sql_where = "AND core_study.id={study_id}".format(study_id=int(study_id))
+            study_scope_join = "JOIN core_studyscoperequest ON core_studyscoperequest.study_id=core_study.id"
+            study_scope_where = "AND core_observation.codeable_concept_id=core_studyscoperequest.scope_code_id"
 
         patient_id_sql_where = ""
         if patient_id:
@@ -1125,10 +1137,12 @@ class Observation(models.Model):
             JOIN core_practitionerorganization ON core_practitionerorganization.organization_id=core_organization.id
             LEFT JOIN core_studypatient ON core_studypatient.patient_id=core_patient.id
             LEFT JOIN core_study ON core_study.id=core_studypatient.study_id
+            {study_scope_join}
             WHERE core_practitionerorganization.practitioner_id = %(practitioner_id)s
             AND core_codeableconcept.coding_system LIKE %(coding_system)s AND core_codeableconcept.coding_code LIKE %(coding_code)s
 
             {study_sql_where}
+            {study_scope_where}
             {patient_id_sql_where}
             {patient_identifier_value_sql_where}
             {observation_sql_where}
@@ -1137,6 +1151,8 @@ class Observation(models.Model):
             """.format(
             SITE_URL=settings.SITE_URL,
             study_sql_where=study_sql_where,
+            study_scope_join=study_scope_join,
+            study_scope_where=study_scope_where,
             patient_id_sql_where=patient_id_sql_where,
             patient_identifier_value_sql_where=patient_identifier_value_sql_where,
             observation_sql_where=observation_sql_where,

--- a/tests/test_observation_scope_filtering.py
+++ b/tests/test_observation_scope_filtering.py
@@ -1,0 +1,435 @@
+"""
+Tests for GHI #228: Observation scope filtering by study
+
+Validates that observations are correctly filtered by study scope codes,
+ensuring that a study requesting only Blood Pressure does NOT surface
+Heart Rate observations (and vice versa), even when the patient is
+enrolled in multiple studies with different scopes.
+
+Also validates the seed command (GHI #193 Bug 1) produces no duplicate
+observations across study groups.
+"""
+
+import pytest
+from django.core.management import call_command
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from core.models import JheUser, Observation, Organization, PractitionerOrganization
+
+from .utils import (
+    Code,
+    add_observations,
+    add_patient_to_study,
+    create_study,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="Test Org", type="other")
+
+
+@pytest.fixture
+def practitioner(org):
+    user = JheUser.objects.create_user(
+        email="scope-practitioner@example.org",
+        password="testpass123",
+        identifier="scope-practitioner",
+        user_type="practitioner",
+    )
+    PractitionerOrganization.objects.create(
+        practitioner=user.practitioner,
+        organization=org,
+        role="manager",
+    )
+    return user
+
+
+@pytest.fixture
+def patient_a(org):
+    user = JheUser.objects.create_user(
+        email="patient-a@example.org",
+        password="testpass123",
+        identifier="patient-a",
+        user_type="patient",
+    )
+    user.patient.organizations.add(org)
+    return user.patient
+
+
+@pytest.fixture
+def patient_b(org):
+    user = JheUser.objects.create_user(
+        email="patient-b@example.org",
+        password="testpass123",
+        identifier="patient-b",
+        user_type="patient",
+    )
+    user.patient.organizations.add(org)
+    return user.patient
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – for_practitioner_organization_study_patient()
+# ---------------------------------------------------------------------------
+
+
+class TestForPractitionerStudyFilters:
+    """Unit tests for Observation.for_practitioner_organization_study_patient()"""
+
+    def test_study_filters_by_scope_code(self, practitioner, org, patient_a):
+        """
+        GHI #228 regression: querying by study_id should only return
+        observations whose codeable_concept matches a StudyScopeRequest.
+        """
+        hr_study = create_study(organization=org, codes=[Code.HeartRate])
+        add_patient_to_study(patient_a, hr_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=3)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=4)
+
+        results = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=hr_study.id,
+            )
+        )
+        assert len(results) == 3
+        codes = {r.codeable_concept.coding_code for r in results}
+        assert codes == {Code.HeartRate.value}
+
+    def test_study_with_multiple_scopes(self, practitioner, org, patient_a):
+        """A study requesting BP + HR should return both, but not glucose."""
+        bp_hr_study = create_study(organization=org, codes=[Code.HeartRate, Code.BloodPressure])
+        add_patient_to_study(patient_a, bp_hr_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=2)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=3)
+        add_observations(patient=patient_a, code=Code.BloodGlucose, n=4)
+
+        results = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=bp_hr_study.id,
+            )
+        )
+        assert len(results) == 5
+        codes = {r.codeable_concept.coding_code for r in results}
+        assert codes == {Code.HeartRate.value, Code.BloodPressure.value}
+
+    def test_no_study_returns_all_observations(self, practitioner, org, patient_a):
+        """When study_id is None, all observations should be returned."""
+        hr_study = create_study(organization=org, codes=[Code.HeartRate])
+        add_patient_to_study(patient_a, hr_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=3)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=4)
+
+        results = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=None,
+            )
+        )
+        assert len(results) == 7
+
+    def test_patient_in_two_studies_different_scopes(self, practitioner, org, patient_a):
+        """
+        GHI #228 core scenario: patient enrolled in HR study AND BP study.
+        Querying by HR study must return only HR observations.
+        """
+        hr_study = create_study(name="HR Only", organization=org, codes=[Code.HeartRate])
+        bp_study = create_study(name="BP Only", organization=org, codes=[Code.BloodPressure])
+        add_patient_to_study(patient_a, hr_study)
+        add_patient_to_study(patient_a, bp_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=5)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=3)
+
+        hr_results = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=hr_study.id,
+            )
+        )
+        assert len(hr_results) == 5
+
+        bp_results = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=bp_study.id,
+            )
+        )
+        assert len(bp_results) == 3
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – fhir_search()
+# ---------------------------------------------------------------------------
+
+
+class TestFhirSearchStudyFilters:
+    """Unit tests for Observation.fhir_search() scope filtering"""
+
+    def test_fhir_search_filters_by_study_scope(self, practitioner, org, patient_a):
+        """fhir_search with study_id should only return matching scope codes."""
+        hr_study = create_study(organization=org, codes=[Code.HeartRate])
+        add_patient_to_study(patient_a, hr_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=4)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=6)
+
+        results = list(
+            Observation.fhir_search(
+                jhe_user_id=practitioner.id,
+                study_id=hr_study.id,
+            )
+        )
+        assert len(results) == 4
+
+    def test_fhir_search_no_study_returns_all(self, practitioner, org, patient_a):
+        """fhir_search without study_id returns all observations."""
+        study = create_study(organization=org, codes=[Code.HeartRate])
+        add_patient_to_study(patient_a, study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=2)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=3)
+
+        results = list(
+            Observation.fhir_search(
+                jhe_user_id=practitioner.id,
+                study_id=None,
+            )
+        )
+        assert len(results) == 5
+
+    def test_fhir_search_two_studies_isolation(self, practitioner, org, patient_a):
+        """Each study should see only its own scope codes through fhir_search."""
+        hr_study = create_study(name="HR", organization=org, codes=[Code.HeartRate])
+        bp_study = create_study(name="BP", organization=org, codes=[Code.BloodPressure])
+        add_patient_to_study(patient_a, hr_study)
+        add_patient_to_study(patient_a, bp_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=3)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=7)
+
+        hr = list(Observation.fhir_search(jhe_user_id=practitioner.id, study_id=hr_study.id))
+        bp = list(Observation.fhir_search(jhe_user_id=practitioner.id, study_id=bp_study.id))
+        assert len(hr) == 3
+        assert len(bp) == 7
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – FHIR API endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestFhirApiObservationByStudyScope:
+    """Integration tests hitting the /fhir/r5/Observation endpoint"""
+
+    @pytest.fixture
+    def api_client(self, practitioner):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.default_format = "json"
+        client.force_authenticate(practitioner)
+        return client
+
+    def test_api_returns_only_study_scoped_observations(self, api_client, org, patient_a):
+        """
+        End-to-end: create HR and BP studies, add patient to both,
+        query via FHIR API with study filter — should get only matching obs.
+        """
+        hr_study = create_study(name="HR API", organization=org, codes=[Code.HeartRate])
+        bp_study = create_study(name="BP API", organization=org, codes=[Code.BloodPressure])
+        add_patient_to_study(patient_a, hr_study)
+        add_patient_to_study(patient_a, bp_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=4)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=6)
+
+        # Query by HR study
+        r = api_client.get(
+            "/fhir/r5/Observation",
+            {"patient._has:Group:member:_id": hr_study.id},
+        )
+        assert r.status_code == 200, f"{r.status_code}: {r.text}"
+        assert r.json()["total"] == 4
+
+        # Query by BP study
+        r = api_client.get(
+            "/fhir/r5/Observation",
+            {"patient._has:Group:member:_id": bp_study.id},
+        )
+        assert r.status_code == 200, f"{r.status_code}: {r.text}"
+        assert r.json()["total"] == 6
+
+    def test_api_no_study_filter_returns_all(self, api_client, org, patient_a):
+        """Without a study filter, all observations for the patient are returned."""
+        study = create_study(organization=org, codes=[Code.HeartRate])
+        add_patient_to_study(patient_a, study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=2)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=3)
+
+        r = api_client.get(
+            "/fhir/r5/Observation",
+            {"patient": patient_a.id},
+        )
+        assert r.status_code == 200, f"{r.status_code}: {r.text}"
+        assert r.json()["total"] == 5
+
+    def test_api_multi_scope_study(self, api_client, org, patient_a):
+        """A study with BP+HR scopes returns both codes but not glucose."""
+        bp_hr = create_study(name="BPHR", organization=org, codes=[Code.HeartRate, Code.BloodPressure])
+        add_patient_to_study(patient_a, bp_hr)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=2)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=3)
+        add_observations(patient=patient_a, code=Code.BloodGlucose, n=4)
+
+        r = api_client.get(
+            "/fhir/r5/Observation",
+            {"patient._has:Group:member:_id": bp_hr.id},
+        )
+        assert r.status_code == 200, f"{r.status_code}: {r.text}"
+        assert r.json()["total"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestObservationBoundaryConditions:
+    """Edge cases and boundary conditions for observation scope filtering"""
+
+    def test_patient_with_no_consents_returns_nothing(self, practitioner, org, patient_a):
+        """A patient with observations but no study enrollment returns nothing when queried by study."""
+        hr_study = create_study(organization=org, codes=[Code.HeartRate])
+        # Patient not added to study
+        add_observations(patient=patient_a, code=Code.HeartRate, n=3)
+
+        results = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=hr_study.id,
+            )
+        )
+        assert len(results) == 0
+
+    def test_patient_consented_no_matching_observations(self, practitioner, org, patient_a):
+        """Patient enrolled in HR study but has only BP observations → 0 results."""
+        hr_study = create_study(organization=org, codes=[Code.HeartRate])
+        add_patient_to_study(patient_a, hr_study)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=5)
+
+        results = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=hr_study.id,
+            )
+        )
+        assert len(results) == 0
+
+    def test_two_patients_same_study_isolated(self, practitioner, org, patient_a, patient_b):
+        """Two patients in same HR study; each patient's obs counted correctly."""
+        hr_study = create_study(organization=org, codes=[Code.HeartRate])
+        add_patient_to_study(patient_a, hr_study)
+        add_patient_to_study(patient_b, hr_study)
+        add_observations(patient=patient_a, code=Code.HeartRate, n=3)
+        add_observations(patient=patient_b, code=Code.HeartRate, n=5)
+
+        # Query for patient_a only
+        results_a = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=hr_study.id,
+                patient_id=patient_a.id,
+            )
+        )
+        assert len(results_a) == 3
+
+        # Query all patients in study
+        results_all = list(
+            Observation.for_practitioner_organization_study_patient(
+                jhe_user_id=practitioner.id,
+                study_id=hr_study.id,
+            )
+        )
+        assert len(results_all) == 8
+
+    def test_three_code_scenario(self, practitioner, org, patient_a):
+        """
+        Three studies with different single scopes.
+        Observations spread across all three codes.
+        Each study query returns only its own code's observations.
+        """
+        hr_study = create_study(name="HR3", organization=org, codes=[Code.HeartRate])
+        bp_study = create_study(name="BP3", organization=org, codes=[Code.BloodPressure])
+        bg_study = create_study(name="BG3", organization=org, codes=[Code.BloodGlucose])
+
+        add_patient_to_study(patient_a, hr_study)
+        add_patient_to_study(patient_a, bp_study)
+        add_patient_to_study(patient_a, bg_study)
+
+        add_observations(patient=patient_a, code=Code.HeartRate, n=2)
+        add_observations(patient=patient_a, code=Code.BloodPressure, n=4)
+        add_observations(patient=patient_a, code=Code.BloodGlucose, n=6)
+
+        hr = list(Observation.for_practitioner_organization_study_patient(
+            jhe_user_id=practitioner.id, study_id=hr_study.id,
+        ))
+        bp = list(Observation.for_practitioner_organization_study_patient(
+            jhe_user_id=practitioner.id, study_id=bp_study.id,
+        ))
+        bg = list(Observation.for_practitioner_organization_study_patient(
+            jhe_user_id=practitioner.id, study_id=bg_study.id,
+        ))
+        assert len(hr) == 2
+        assert len(bp) == 4
+        assert len(bg) == 6
+
+
+# ---------------------------------------------------------------------------
+# Seed command test
+# ---------------------------------------------------------------------------
+
+
+class TestSeedNoDuplicateObservations:
+    """Validates that the seed command does not produce duplicate observations (GHI #193 Bug 1)"""
+
+    def test_seed_observation_counts(self, db):
+        """
+        Run the seed command and verify:
+        - Total count matches expected consents (no Bug 1 duplicates)
+        - Berkeley and UCSF observations are correctly scoped
+        """
+        call_command("seed", "--flush-db")
+        observations = Observation.objects.all()
+
+        # Expected consents:
+        # Berkeley:
+        #   peter  → bp_hr(BP, HR) = 2 obs
+        #   pamela → bp_hr(BP, HR) + bp(BP) = 3 obs  (2 BP obs is correct: one per consent)
+        # UCSF:
+        #   percy → mosl_bt(BT) = 1 obs
+        #   paul  → olgin_o2(O2) = 1 obs
+        #   pat   → cardio_rr(RR) + olgin_o2(O2) = 2 obs
+        # Total = 5 + 4 = 9
+        assert observations.count() == 9, (
+            f"Expected 9 observations (5 berkeley + 4 ucsf), got {observations.count()}"
+        )
+
+        # Verify no cross-contamination from Bug 1:
+        # Berkeley patients should not have UCSF-only codes (RR, BT, O2)
+        from core.models import CodeableConcept, JheUser
+
+        berkeley_emails = ["peter@example.com", "pamela@example.com"]
+        berkeley_patients = [JheUser.objects.get(email=e).patient for e in berkeley_emails]
+        ucsf_only_codes = CodeableConcept.objects.filter(
+            coding_code__in=["omh:respiratory-rate:2.0", "omh:body-temperature:4.0", "omh:oxygen-saturation:2.0"]
+        )
+        cross_contaminated = observations.filter(
+            subject_patient__in=berkeley_patients,
+            codeable_concept__in=ucsf_only_codes,
+        )
+        assert cross_contaminated.count() == 0, (
+            f"Bug 1 regression: Berkeley patients have UCSF observations: {list(cross_contaminated.values_list('subject_patient__jhe_user__email', 'codeable_concept__coding_code'))}"
+        )

--- a/tests/test_observation_viewset.py
+++ b/tests/test_observation_viewset.py
@@ -191,7 +191,6 @@ def test_get_observation_by_study(api_client, patient, hr_study):
     assert len(observations) == 10
 
 
-@pytest.mark.xfail(reason="studies have access to all patient data if a patient is in the study")
 def test_get_observation_one_patient_two_studies(api_client, patient, hr_study):
 
     org2 = Organization.objects.create(


### PR DESCRIPTION
…vation scope filtering

- renamed all real institution/lab names to fictional Example names (GHI #193/#227)
- fixed seed observation loops to scope consents locally (GHI #228 Bug 1)
- added JOIN core_studyscoperequest to filter observations by study scope (GHI #228 Bug 2)
- removed @pytest.mark.xfail from now-passing test
- added 15 new tests in test_observation_scope_filtering.py
- updated iglu.py and README.md references