### PR TITLE
test: declare ow.ingest_mode in stale-lock test to fix suite-order flake

### DIFF
--- a/tests/test_ow_poll.py
+++ b/tests/test_ow_poll.py
@@ -294,6 +294,7 @@ def test_stale_lock_is_force_released(db, ow_user, patient_with_consent, hr_conc
     from core.management.commands.ow_poll import LOCK_STALE_AFTER
 
     _set_jhe_setting("module.ow", True)
+    _set_jhe_setting("ow.ingest_mode", "normalized", value_type="string")
     # Held longer than the stale window -> treat as abandoned (crashed worker).
     stale_at = timezone.now() - (LOCK_STALE_AFTER + timedelta(minutes=1))
     _hold_sync_lock(acquired_at=stale_at)


### PR DESCRIPTION
test_stale_lock_is_force_released inherited ow.ingest_mode='bogus' leaked via the process-wide settings cache from test_unknown_mode_aborts (DB rolls back, cache does not), aborting the poll so 0 observations were created. Set the mode explicitly so the test is order-independent.

Closes #454