### PR TITLE
fix: drop superseded client.invitation_url settings in migration 0030

### DIFF
--- a/core/migrations/0030_remove_jhesetting_setting_id.py
+++ b/core/migrations/0030_remove_jhesetting_setting_id.py
@@ -1,6 +1,14 @@
 from django.db import migrations, models
 
 
+def delete_superseded_client_invitation_url_settings(apps, schema_editor):
+    # 0027 moved each client's value into JheClient.invitation_url. With setting_id
+    # dropped and key made globally unique, these per-client rows would violate the
+    # new unique(key) constraint, so remove the now-redundant rows.
+    JheSetting = apps.get_model("core", "JheSetting")
+    JheSetting.objects.filter(key="client.invitation_url").delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -8,6 +16,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(
+            delete_superseded_client_invitation_url_settings,
+            migrations.RunPython.noop,
+        ),
         migrations.RemoveConstraint(
             model_name="jhesetting",
             name="core_jhesetting_unique_key_setting_id",


### PR DESCRIPTION
Migration 0027 backfilled per-client invitation URLs into JheClient. 0030 makes JheSetting.key globally unique but left the old per-client rows in place, breaking the unique index on databases with real client data (prod). Delete them before applying the constraint.