### PR TITLE
ci: make smoke_test.yml reusable and call it from fly_dev post-deploy

### DIFF
--- a/.github/workflows/fly_dev.yml
+++ b/.github/workflows/fly_dev.yml
@@ -76,33 +76,10 @@ jobs:
   smoke-test:
     name: Post-deploy smoke tests
     needs: deploy
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        persist-credentials: false
-
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-      with:
-        python-version: "3.11"
-
-    - name: Install test dependencies
-      run: pip install pytest requests
-
-    - name: Wait for deployment to stabilize
-      run: |
-        echo "Waiting 30s for Fly machines to stabilize after deploy..."
-        sleep 30
-
-    - name: Run smoke tests
-      run: |
-        pytest tests/smoke/test_smoke.py \
-          --smoke-url=https://jhe.fly.dev \
-          -m smoke \
-          -v \
-          --tb=short \
-          --no-header \
-          -p no:cacheprovider \
-          --override-ini="addopts=" \
-          --override-ini="DJANGO_SETTINGS_MODULE="
+    # Reuse the single smoke-test definition (smoke_test.yml) rather than
+    # inlining a duplicate pytest block here.
+    permissions:
+      contents: read
+    uses: ./.github/workflows/smoke_test.yml
+    with:
+      smoke_url: https://jhe.fly.dev

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -1,6 +1,20 @@
-name: Smoke Tests (on-demand)
+name: Smoke Tests
 
 on:
+  # Reusable entry point: called by other workflows (e.g. fly_dev.yml
+  # post-deploy) so there is a single smoke-test definition.
+  workflow_call:
+    inputs:
+      smoke_url:
+        description: "Base URL of the JHE instance to test (e.g. https://jhe.fly.dev)"
+        required: true
+        type: string
+      python_version:
+        description: "Python version to use"
+        required: false
+        default: "3.11"
+        type: string
+  # Manual entry point for ad-hoc URLs.
   workflow_dispatch:
     inputs:
       smoke_url:


### PR DESCRIPTION
Convert smoke_test.yml to a workflow_call reusable workflow (keeping the manual workflow_dispatch entry point) and replace the inline pytest block in fly_dev.yml's post-deploy smoke-test job with a uses: of it, so there is a single smoke-test definition.

Refs #505