### PR TITLE
ci: run smoke tests daily against jhe.fly.dev on a schedule

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -7,7 +7,8 @@ on:
     inputs:
       smoke_url:
         description: "Base URL of the JHE instance to test (e.g. https://jhe.fly.dev)"
-        required: true
+        required: false
+        default: "https://jhe.fly.dev"
         type: string
       python_version:
         description: "Python version to use"
@@ -19,46 +20,54 @@ on:
     inputs:
       smoke_url:
         description: "Base URL of the JHE instance to test (e.g. https://jhe.fly.dev)"
-        required: true
+        required: false
+        default: "https://jhe.fly.dev"
         type: string
       python_version:
         description: "Python version to use"
         required: false
         default: "3.11"
         type: string
+  # Continuously verify the live jhe.fly.dev instance so regressions surface
+  # without waiting for a deploy. Scheduled runs pass no inputs, so the job
+  # falls back to the jhe.fly.dev / 3.11 defaults below.
+  schedule:
+    - cron: "0 6 * * *"
 
 permissions:
   contents: read
 
+env:
+  SMOKE_URL: ${{ inputs.smoke_url || 'https://jhe.fly.dev' }}
+  PYTHON_VERSION: ${{ inputs.python_version || '3.11' }}
+
 jobs:
   smoke-test:
-    name: "Smoke → ${{ inputs.smoke_url }}"
+    name: "Smoke → ${{ inputs.smoke_url || 'https://jhe.fly.dev' }}"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
 
-    - name: Set up Python ${{ inputs.python_version }}
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
-        python-version: ${{ inputs.python_version }}
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install test dependencies
       run: pip install pytest requests
 
     - name: Wait for instance to wake up
       run: |
-        echo "Pinging ${INPUTS_SMOKE_URL}/health to warm up the instance..."
+        echo "Pinging ${SMOKE_URL}/health to warm up the instance..."
         curl -sf --retry 3 --retry-delay 5 --max-time 30 \
-          "${INPUTS_SMOKE_URL}/health" || echo "Warm-up ping failed (may cold-start during tests)"
-      env:
-        INPUTS_SMOKE_URL: ${{ inputs.smoke_url }}
+          "${SMOKE_URL}/health" || echo "Warm-up ping failed (may cold-start during tests)"
 
     - name: Run smoke tests
       run: |
         pytest tests/smoke/test_smoke.py \
-          --smoke-url=${INPUTS_SMOKE_URL} \
+          --smoke-url=${SMOKE_URL} \
           -m smoke \
           -v \
           --tb=short \
@@ -66,5 +75,3 @@ jobs:
           -p no:cacheprovider \
           --override-ini="addopts=" \
           --override-ini="DJANGO_SETTINGS_MODULE="
-      env:
-        INPUTS_SMOKE_URL: ${{ inputs.smoke_url }}


### PR DESCRIPTION
Add a daily schedule trigger to smoke_test.yml so the live jhe.fly.dev instance is continuously verified without waiting for a deploy. Scheduled runs pass no inputs, so smoke_url/python_version fall back to jhe.fly.dev / 3.11 via workflow-level env.

Closes #505