### PR TITLE
fix: hide auth error box by default (#501)

### DIFF
--- a/core/templates/common/auth/callback.html
+++ b/core/templates/common/auth/callback.html
@@ -7,7 +7,7 @@
       <span class="sr-only"></span>
     </div>
   </div>
-  <div id="authError" class="alert alert-danger d-inline-block text-start" role="alert" style="display: none;">
+  <div id="authError" class="alert alert-danger text-start" role="alert" style="display: none;">
     <h5 class="mb-2">Sign-in failed</h5>
     <div id="authErrorMessage" class="mb-3"></div>
     <a href="{% url 'login' %}" class="btn btn-primary btn-sm" onclick="clearAuthError()">Back to Log In</a>

--- a/core/templates/common/auth/callback_popup.html
+++ b/core/templates/common/auth/callback_popup.html
@@ -7,7 +7,7 @@
       <span class="sr-only"></span>
     </div>
   </div>
-  <div id="authError" class="alert alert-danger d-inline-block text-start" role="alert" style="display: none;">
+  <div id="authError" class="alert alert-danger text-start" role="alert" style="display: none;">
     <h5 class="mb-2">Sign-in failed</h5>
     <div id="authErrorMessage" class="mb-3"></div>
     <a href="{% url 'login' %}" class="btn btn-primary btn-sm" onclick="clearAuthError()">Back to Log In</a>

--- a/core/templates/common/auth/login.html
+++ b/core/templates/common/auth/login.html
@@ -7,7 +7,7 @@
       <span class="sr-only"></span>
     </div>
   </div>
-  <div id="authError" class="alert alert-danger d-inline-block text-start" role="alert" style="display: none;">
+  <div id="authError" class="alert alert-danger text-start" role="alert" style="display: none;">
     <h5 class="mb-2">Sign-in failed</h5>
     <div id="authErrorMessage" class="mb-3"></div>
     <a href="{% url 'login' %}" class="btn btn-primary btn-sm" onclick="clearAuthError()">Back to Log In</a>


### PR DESCRIPTION
PR #496 added Bootstrap's d-inline-block (display:inline-block !important) to the #authError box while hiding it with a non-important inline display:none, so the box was never hidden and flashed red on every successful login. Drop d-inline-block to match the existing #errorAlert hide/show convention; showAuthError() still reveals it via style.display.

closes #501 