### PR TITLE
fix: return clear 400 when adding a patient already in an organizatio…

### DIFF
--- a/core/static/clients/jhe-admin/js/client-jhe-admin.js
+++ b/core/static/clients/jhe-admin/js/client-jhe-admin.js
@@ -1030,9 +1030,9 @@ async function globalLookupPatientByEmail(email, organizationId) {
       (org) => org.id === organizationId
     );
     if (matchingOrganization) {
-      return alert(
-        `Patient with E-mail ${email} is already a member of ${matchingOrganization.name}`
-      );
+      return displayModalValidationError([
+        `Patient with E-mail ${email} is already a member of ${matchingOrganization.name}`,
+      ]);
     }
     await navReturnFromCrud();
     await nav("patients", {

--- a/core/views/patient.py
+++ b/core/views/patient.py
@@ -180,6 +180,8 @@ class PatientViewSet(ModelViewSet):
         organization = Organization.objects.get(pk=organization_id)
         if not organization:
             raise ValidationError("Organization could not be found")
+        if PatientOrganization.objects.filter(organization_id=organization.id, patient_id=patient.id).exists():
+            raise ValidationError("This patient is already a member of this organization.")
         PatientOrganization.objects.create(organization_id=organization.id, patient_id=patient.id)
         return Response(PatientSerializer(patient, many=False).data, status=200)
 

--- a/tests/backend/test_patient_viewset.py
+++ b/tests/backend/test_patient_viewset.py
@@ -213,6 +213,26 @@ def test_identifier_unique_system_value_constraint(organization):
         PatientIdentifier.objects.create(patient=patient_b, system="http://hospital-a.org", value="MRN-DUP")
 
 
+def test_global_add_organization_duplicate(api_client, organization):
+    # Adding a patient who is already a member of the organization must return a
+    # clear 400 (issue #238), not a 500 internal server error.
+    r = api_client.post(
+        "/api/v1/patients",
+        {
+            "organizationId": organization.id,
+            "telecomEmail": "dup-org-member@example.com",
+            "birthDate": "2000-01-01",
+        },
+        format="json",
+    )
+    assert r.status_code == 200, r.text
+    patient_id = r.json()["id"]
+
+    r = api_client.patch(f"/api/v1/patients/{patient_id}/global_add_organization?organization_id={organization.id}")
+    assert r.status_code == 400, r.text
+    assert "already a member" in r.text
+
+
 def test_update_replaces_identifiers(api_client, organization):
     r = api_client.post(
         "/api/v1/patients",


### PR DESCRIPTION
…n (#238)

Adding a patient already in an org raised IntegrityError -> 500 rendered on a banner hidden behind the modal. Guard the duplicate in global_add_organization and raise ValidationError (400) so apiRequest surfaces it in the modal banner. Replace the native alert() duplicate-warning with the existing displayModalValidationError banner. Adds a regression test.

closes #238 