### PR TITLE
feat: add OMH forced-vital-capacity and forced-expiratory-volume-1-se…

### DIFF
--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -145,6 +145,16 @@ class Command(BaseCommand):
             ),
             ("https://w3id.org/openmhealth", "omh:rr-interval:1.0", "RR Interval"),
             ("https://w3id.org/openmhealth", "omh:body-weight:3.0", "Body weight"),
+            (
+                "https://w3id.org/openmhealth",
+                "omh:forced-vital-capacity:1.0",
+                "Forced vital capacity",
+            ),
+            (
+                "https://w3id.org/openmhealth",
+                "omh:forced-expiratory-volume-1-second:1.0",
+                "Forced expiratory volume 1 second",
+            ),
             ("http://hl7.org/fhir/", "QuestionnaireResponse", "FHIR QuestionnaireResponse"),
         ]
         # bulk create thing

--- a/data/omh/json-schemas/data/schema-omh_forced-expiratory-volume-1-second_1-0.json
+++ b/data/omh/json-schemas/data/schema-omh_forced-expiratory-volume-1-second_1-0.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/openmhealth/schemas/omh/forced-expiratory-volume-1-second-1.0.json",
+    "description": "This schema represents a person's forced expired volume in 1 second (FEV1), the volume of air (in liters) forcibly blown out of the lungs in 1 second after maximal inspiration.",
+    "type": "object",
+    "references": [
+        {
+            "description": "The SNOMED code represents expired volume in 1 second (observable entity)",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/59328004"
+        }
+    ],
+
+    "definitions": {
+        "volume_unit_value": {
+            "$ref": "volume-unit-value-1.x.json"
+        },
+        "time_frame": {
+            "$ref": "https://w3id.org/ieee/ieee-1752-schema/time-frame-1.0.json"
+        },
+        "temporal_relationship_to_physical_activity": {
+            "$ref": "temporal-relationship-to-physical-activity-1.x.json"
+        },
+        "descriptive_statistic": {
+            "$ref": "https://w3id.org/ieee/ieee-1752-schema/descriptive-statistic-1.0.json"
+        }
+    },
+
+    "properties": {
+        "forced_expiratory_volume_1_second": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/volume_unit_value"
+                },
+                {
+                    "properties": {
+                        "unit": {
+                            "enum": [
+                                "L"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "measurement_quality": {
+            "description": "data quality label",
+            "enum": [
+                "acceptable",
+                "usable",
+                "rejected"
+            ]
+        },
+        "effective_time_frame": {
+            "description": "The date-time at which, or time interval during which the measurement is asserted as being valid.",
+            "$ref": "#/definitions/time_frame"
+        },
+        "descriptive_statistic": {
+            "description": "The  statistic is a set of measurements (eg. average, maximum) within the specified time frame.",
+            "$ref": "#/definitions/descriptive_statistic"
+        },
+        "temporal_relationship_to_physical_activity": {
+            "$ref": "#/definitions/temporal_relationship_to_physical_activity"
+        }
+    },
+
+    "required": [
+        "forced_expiratory_volume_1_second",
+        "effective_time_frame"
+    ]
+}

--- a/data/omh/json-schemas/data/schema-omh_forced-vital-capacity_1-0.json
+++ b/data/omh/json-schemas/data/schema-omh_forced-vital-capacity_1-0.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/openmhealth/schemas/omh/forced-vital-capacity-1.0.json",
+    "description": "This schema represents a person's forced vital capacity (FVC), the total volume of air (in liters) blown out of the lungs during forced exhalation after maximal inspiration.",
+    "type": "object",
+    "references": [
+        {
+            "description": "The SNOMED code represents Forced vital capacity (observable entity)",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/50834005"
+        }
+    ],
+
+    "definitions": {
+        "volume_unit_value": {
+            "$ref": "volume-unit-value-1.x.json"
+        },
+        "time_frame": {
+            "$ref": "https://w3id.org/ieee/ieee-1752-schema/time-frame-1.0.json"
+        },
+        "temporal_relationship_to_physical_activity": {
+            "$ref": "temporal-relationship-to-physical-activity-1.x.json"
+        },
+        "descriptive_statistic": {
+            "$ref": "https://w3id.org/ieee/ieee-1752-schema/descriptive-statistic-1.0.json"
+        }
+    },
+
+    "properties": {
+        "forced_vital_capacity": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/volume_unit_value"
+                },
+                {
+                    "properties": {
+                        "unit": {
+                            "enum": [
+                                "L"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "measurement_quality": {
+            "description": "data quality label",
+            "enum": [
+                "acceptable",
+                "usable",
+                "rejected"
+            ]
+        },
+        "effective_time_frame": {
+            "description": "The date-time at which, or time interval during which the measurement is asserted as being valid.",
+            "$ref": "#/definitions/time_frame"
+        },
+        "descriptive_statistic": {
+            "description": "The  statistic is a set of measurements (eg. average, maximum) within the specified time frame.",
+            "$ref": "#/definitions/descriptive_statistic"
+        },
+        "temporal_relationship_to_physical_activity": {
+            "$ref": "#/definitions/temporal_relationship_to_physical_activity"
+        }
+    },
+    "required": [
+        "forced_vital_capacity",
+        "effective_time_frame"
+    ]
+}

--- a/data/omh/json-schemas/utility/temporal-relationship-to-physical-activity-1.x.json
+++ b/data/omh/json-schemas/utility/temporal-relationship-to-physical-activity-1.x.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "type": "string",
+    "description": "The temporal relationship of a clinical measure or assessment to physical activity. ",
+    "references": [
+        {
+            "value": "at rest",
+            "description": "The SNOMED code represents At rest (qualifier value)",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/263678003"
+        },
+        {
+            "value": "active",
+            "description": "The SNOMED code represents Active (qualifier value).",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/55561003"
+        },
+        {
+            "value": "before exercise",
+            "description": "The SNOMED code represents Before exercise (qualifier value)",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/307166007"
+        },
+        {
+            "value": "after exercise",
+            "description": "The SNOMED code represents After exercise (qualifier value)",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/255214003"
+        },
+        {
+            "value": "during exercise",
+            "description": "The SNOMED code represents During exercise (qualifier value)",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/309604004"
+        }
+    ],
+    "enum": [
+        "at rest",
+        "active",
+        "before exercise",
+        "after exercise",
+        "during exercise"
+    ]
+}

--- a/data/omh/json-schemas/utility/volume-unit-value-1.x.json
+++ b/data/omh/json-schemas/utility/volume-unit-value-1.x.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3id.org/openmhealth/schemas/omh/volume-unit-value-1.1.json",
+    "description": "This schema represents a volume.",
+    "type": "object",
+
+    "references": [
+        {
+            "description": "The SNOMED code represents Volume",
+            "url": "http://purl.bioontology.org/ontology/SNOMEDCT/118565006"
+        }
+    ],
+    "allOf": [
+        {
+            "$ref": "https://w3id.org/ieee/ieee-1752-schema/unit-value-1.0.json"
+        },
+        {
+            "properties": {
+                "unit": {
+                    "references": [
+                        {
+                            "description": "The unit of measure of the element. Basic unit is liter (L). Allowed values are drawn from the Volume Units and English Volume Units Common Synonyms (non-UCUM). The valid UCUM code is different for fluid ounce ([foz_us]), cubic inch ([cin_i]), cup ([cup_us]), pint ([pt_us]), quart ([qt_us]), gallon ([gal_us]). 1 teaspoon = 5 ml; 1 tablespoon = 3 teaspoons = 15 ml.",
+                            "url": "http://download.hl7.de/documents/ucum/ucumdata.html"
+                        }
+                    ],
+                    "enum": [
+                        "fL",
+                        "pL",
+                        "nL",
+                        "uL",
+                        "mL",
+                        "cL",
+                        "dL",
+                        "L",
+                        "kL",
+                        "fl oz",
+                        "Cup",
+                        "in^3",
+                        "pt",
+                        "qt",
+                        "gal",
+                        "tsp",
+                        "tbsp"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/test_spirometry_schema_validation.py
+++ b/tests/test_spirometry_schema_validation.py
@@ -1,0 +1,76 @@
+"""OMH body-schema validation tests for the spirometry schemas (FVC, FEV1).
+
+Covers the two schemas added from openmhealth/schemas (forced-vital-capacity-1.0,
+forced-expiratory-volume-1-second-1.0). Each $refs the volume-unit-value-1.x and
+temporal-relationship-to-physical-activity-1.x utility schemas, which must resolve
+from the local registry so non-compliant values (e.g. a non-liter unit) are rejected
+with a ValidationError rather than silently accepted or failing to resolve the $ref.
+"""
+
+import json
+
+import pytest
+from django.conf import settings
+from jsonschema import ValidationError
+
+from core.utils import validate_with_registry
+
+FVC_BODY_SCHEMA = json.loads(
+    (settings.DATA_DIR_PATH.schemas_data / "schema-omh_forced-vital-capacity_1-0.json").read_text()
+)
+FEV1_BODY_SCHEMA = json.loads(
+    (settings.DATA_DIR_PATH.schemas_data / "schema-omh_forced-expiratory-volume-1-second_1-0.json").read_text()
+)
+
+
+def _fvc_body(**overrides):
+    body = {
+        "forced_vital_capacity": {"unit": "L", "value": 4.2},
+        "effective_time_frame": {"date_time": "2025-01-01T00:00:00Z"},
+    }
+    body.update(overrides)
+    return body
+
+
+def _fev1_body(**overrides):
+    body = {
+        "forced_expiratory_volume_1_second": {"unit": "L", "value": 3.1},
+        "effective_time_frame": {"date_time": "2025-01-01T00:00:00Z"},
+    }
+    body.update(overrides)
+    return body
+
+
+def test_fvc_minimal_compliant_body_passes():
+    validate_with_registry(instance=_fvc_body(), schema=FVC_BODY_SCHEMA)
+
+
+def test_fev1_minimal_compliant_body_passes():
+    validate_with_registry(instance=_fev1_body(), schema=FEV1_BODY_SCHEMA)
+
+
+def test_fvc_invalid_unit_rejected():
+    # OMH constrains the spirometry value to liters ("L"); "mL" is non-compliant.
+    body = _fvc_body()
+    body["forced_vital_capacity"]["unit"] = "mL"
+    with pytest.raises(ValidationError):
+        validate_with_registry(instance=body, schema=FVC_BODY_SCHEMA)
+
+
+def test_fev1_invalid_unit_rejected():
+    body = _fev1_body()
+    body["forced_expiratory_volume_1_second"]["unit"] = "mL"
+    with pytest.raises(ValidationError):
+        validate_with_registry(instance=body, schema=FEV1_BODY_SCHEMA)
+
+
+@pytest.mark.parametrize("value", ["at rest", "active", "before exercise", "after exercise", "during exercise"])
+def test_fvc_valid_temporal_relationship_to_physical_activity_passes(value):
+    validate_with_registry(instance=_fvc_body(temporal_relationship_to_physical_activity=value), schema=FVC_BODY_SCHEMA)
+
+
+def test_fvc_invalid_temporal_relationship_to_physical_activity_rejected():
+    with pytest.raises(ValidationError):
+        validate_with_registry(
+            instance=_fvc_body(temporal_relationship_to_physical_activity="unknown"), schema=FVC_BODY_SCHEMA
+        )


### PR DESCRIPTION
…cond schemas

Adds the two spirometry codeable concepts (omh:forced-vital-capacity:1.0, omh:forced-expiratory-volume-1-second:1.0) to the seed, vendors the body schemas plus their volume-unit-value-1.x and
temporal-relationship-to-physical-activity-1.x deps, and adds schema validation tests. Mirrors the body-weight addition in #461.