### PR TITLE
fix: stop User delete crash and orphan (#533)

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -33,6 +33,24 @@ class JheUserAdmin(admin.ModelAdmin):
     list_display = ("email", "first_name", "last_name", "identifier", "is_staff", "is_active")
     search_fields = ("email", "first_name", "last_name", "identifier")
     list_filter = ("is_staff", "is_active", "is_superuser")
+    # The groups / user_permissions M2M tables were dropped (migration 0011), so the default
+    # admin machinery crashes when it touches them. Hide the fields and route every delete path
+    # through the model's safe JheUser.delete() (which never references those tables).
+    exclude = ("groups", "user_permissions")
+
+    def get_deleted_objects(self, objs, request):
+        # Skip Django's collector (it walks the dropped M2M relations and raises
+        # ProgrammingError). The cascade is handled by JheUser.delete().
+        to_delete = [str(obj) for obj in objs]
+        model_count = {JheUser._meta.verbose_name_plural: len(to_delete)}
+        return to_delete, model_count, set(), []
+
+    def delete_model(self, request, obj):
+        obj.delete()
+
+    def delete_queryset(self, request, queryset):
+        for obj in queryset:
+            obj.delete()
 
 
 @admin.register(Organization)

--- a/core/views/practitioner.py
+++ b/core/views/practitioner.py
@@ -1,9 +1,10 @@
 import logging
 
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from core.models import Practitioner
+from core.models import Patient, Practitioner
 from core.permissions import IsSuperUser
 from core.serializers import (
     PractitionerSerializer,
@@ -16,3 +17,16 @@ class PractitionerViewSet(ModelViewSet):
     serializer_class = PractitionerSerializer
     queryset = Practitioner.objects.all()
     permission_classes = [IsAuthenticated, IsSuperUser]
+
+    def destroy(self, request, *args, **kwargs):
+        practitioner = self.get_object()
+        user = practitioner.jhe_user
+        practitioner.delete()
+
+        # Remove the now-orphaned JheUser so the email is reusable. Mirrors the patient
+        # delete path (core/views/patient.py). Keep the user if another profile still
+        # references it, or if it is a superuser (avoid deleting admin logins).
+        if user and not user.is_superuser and not Patient.objects.filter(jhe_user_id=user.id).exists():
+            user.delete()
+
+        return Response({"success": True})

--- a/tests/backend/test_admin_user_delete.py
+++ b/tests/backend/test_admin_user_delete.py
@@ -1,0 +1,53 @@
+"""
+Issue #533: the Django admin must be able to view and delete a JheUser even though the
+groups / user_permissions M2M tables were dropped (migration 0011). Default ModelAdmin
+machinery queries those dropped tables (`core_jheuser_groups`) and crashes.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+JheUser = get_user_model()
+
+
+@pytest.fixture
+def admin_client(db, client):
+    su = JheUser.objects.create_superuser(email="admin@example.org", password="pw")
+    client.force_login(su)
+    return client
+
+
+@pytest.fixture
+def target(db):
+    return JheUser.objects.create_user(email="target@ucsf.edu", password="x", user_type="practitioner")
+
+
+def test_change_view_loads(admin_client, target):
+    url = reverse("admin:core_jheuser_change", args=[target.id])
+    r = admin_client.get(url)
+    assert r.status_code == 200
+
+
+def test_single_delete_confirm_and_execute(admin_client, target):
+    url = reverse("admin:core_jheuser_delete", args=[target.id])
+    # confirmation page must render (collector must not hit core_jheuser_groups)
+    assert admin_client.get(url).status_code == 200
+    # POST confirms the delete
+    r = admin_client.post(url, {"post": "yes"})
+    assert r.status_code in (200, 302)
+    assert not JheUser.objects.filter(id=target.id).exists()
+
+
+def test_bulk_delete_selected(admin_client, target):
+    url = reverse("admin:core_jheuser_changelist")
+    # step 1: choose action, get the confirmation page
+    confirm = admin_client.post(url, {"action": "delete_selected", "_selected_action": [str(target.id)]})
+    assert confirm.status_code == 200
+    # step 2: confirm
+    r = admin_client.post(
+        url,
+        {"action": "delete_selected", "_selected_action": [str(target.id)], "post": "yes"},
+    )
+    assert r.status_code in (200, 302)
+    assert not JheUser.objects.filter(id=target.id).exists()

--- a/tests/backend/test_practitioner_viewset.py
+++ b/tests/backend/test_practitioner_viewset.py
@@ -1,7 +1,66 @@
 import pytest
 from rest_framework.test import APIClient
 
+from core.models import JheUser, Patient, Practitioner
+
 from .utils import fetch_paginated
+
+
+def _superuser_client(superuser):
+    api_client = APIClient()
+    api_client.default_format = "json"
+    api_client.force_authenticate(superuser)
+    return api_client
+
+
+def _make_practitioner(email, **user_kwargs):
+    user = JheUser.objects.create_user(
+        email=email,
+        password="testpass123",
+        identifier=email,
+        user_type="practitioner",
+        **user_kwargs,
+    )
+    return user, user.practitioner
+
+
+def test_delete_practitioner_removes_orphan_user(superuser):
+    user, practitioner = _make_practitioner("orphan-prac@example.org")
+    api_client = _superuser_client(superuser)
+
+    r = api_client.delete(f"/api/v1/practitioners/{practitioner.id}")
+
+    assert r.status_code in (200, 204), r.text
+    assert not Practitioner.objects.filter(id=practitioner.id).exists()
+    assert not JheUser.objects.filter(email="orphan-prac@example.org").exists()
+    # email is now reusable
+    JheUser.objects.create_user(email="orphan-prac@example.org", password="x", user_type="practitioner")
+    assert JheUser.objects.filter(email="orphan-prac@example.org").count() == 1
+
+
+def test_delete_practitioner_preserves_superuser(superuser):
+    user, practitioner = _make_practitioner("admin-prac@example.org", is_superuser=True, is_staff=True)
+    api_client = _superuser_client(superuser)
+
+    r = api_client.delete(f"/api/v1/practitioners/{practitioner.id}")
+
+    assert r.status_code in (200, 204), r.text
+    assert not Practitioner.objects.filter(id=practitioner.id).exists()
+    # superuser login is preserved
+    assert JheUser.objects.filter(email="admin-prac@example.org").exists()
+
+
+def test_delete_practitioner_preserves_user_with_patient_profile(superuser):
+    user, practitioner = _make_practitioner("dual-role@example.org")
+    Patient.objects.create(jhe_user=user, name_family="Last", name_given="First", birth_date="2000-01-01")
+    api_client = _superuser_client(superuser)
+
+    r = api_client.delete(f"/api/v1/practitioners/{practitioner.id}")
+
+    assert r.status_code in (200, 204), r.text
+    assert not Practitioner.objects.filter(id=practitioner.id).exists()
+    # user kept because a Patient profile still references it
+    assert JheUser.objects.filter(email="dual-role@example.org").exists()
 
 
 def test_list_practitioners(superuser):


### PR DESCRIPTION
Admin: exclude dropped groups/user_permissions M2M and route deletes through the safe JheUser.delete(); practitioner delete now removes the orphaned JheUser (guards superusers and users with a Patient profile).