### PR TITLE
fix(mcp_server): bump omh-shim to 1.3.0 + add Dependabot uv coverage

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -44,3 +44,21 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
+
+  # MCP server (uv project). Keeps the uv.lock current — notably omh-shim,
+  # which adds OMH schemas frequently; the test_covers_jhe_seeded_codes drift
+  # guard gates each bump in CI.
+  - package-ecosystem: uv
+    directory: /mcp_server
+    groups:
+      # one big pull request for minor/patch bumps
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -17,7 +17,12 @@ dependencies = [
     "pydantic>=2.13,<3",
     "fastapi>=0.136,<1",
     "uvicorn[standard]>=0.47,<1",
-    "omh-shim>=1.2.0",
+    # First-party, additive (new OMH schemas land frequently). Floor must cover
+    # every OMH code JHE seeds — see tests/unit/test_omh_registry.py drift guard;
+    # 1.3.0 adds the spirometry schemas (forced-vital-capacity,
+    # forced-expiratory-volume-1-second). Uncapped so additive releases flow;
+    # Dependabot (.github/dependabot.yaml, uv / mcp_server) moves the lock.
+    "omh-shim>=1.3.0",
     "cryptography>=44,<49",
 ]
 

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -319,7 +319,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.136,<1" },
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "mcp", specifier = ">=1.27,<1.28" },
-    { name = "omh-shim", specifier = ">=1.2.0" },
+    { name = "omh-shim", specifier = ">=1.3.0" },
     { name = "pydantic", specifier = ">=2.13,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
@@ -383,15 +383,15 @@ wheels = [
 
 [[package]]
 name = "omh-shim"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/ca/053beaa8859d27fea1ddf47ccfa154387cec9274064f99e7b81351e065e8/omh_shim-1.2.0.tar.gz", hash = "sha256:9d5ba450603c81845ac9b4ae16dff1fc8c995c0232d9c7eef8f6b30a582f2004", size = 36570, upload-time = "2026-06-03T21:28:53.387Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/56/54dcca25e4a723a961ba1b54ee6b9b26f3ddb3b29d97c14def9113e1e06f/omh_shim-1.3.0.tar.gz", hash = "sha256:2577736c4f7c61299ba2cef8df74e6ecf1868abf1e9f46e2a4b48b19fd8317f0", size = 37366, upload-time = "2026-06-11T23:12:28.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/f7/10bca4d0d6f88f5519f167e44be3c5c5bcd131388b816a890fceb65ebfbc/omh_shim-1.2.0-py3-none-any.whl", hash = "sha256:ae1baaf6f50f15c775c15b56ccb13c5bead2b876477946c69321dec14876a10f", size = 52426, upload-time = "2026-06-03T21:28:52.058Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/56/95eeb31688a902183922e82717a0b91da0712802b65ab0466636a3cc69e5/omh_shim-1.3.0-py3-none-any.whl", hash = "sha256:03b83ba1f7231882d9fd89d6d971ec94ac97eb877024f0ff11fe6627e71fb76f", size = 55259, upload-time = "2026-06-11T23:12:27.359Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The `mcp_server` CI (`Lint and unit tests`) fails on `main` whenever it runs — `tests/unit/test_omh_registry.py::test_covers_jhe_seeded_codes`:

```
AssertionError: omh-shim is missing JHE-seeded OMH code(s):
['forced-expiratory-volume-1-second', 'forced-vital-capacity']
```

This is a **deliberate drift guard** working as designed: it parses JHE's `seed_codeable_concepts` and asserts omh-shim serves a schema for every seeded code. JHE seeds the two spirometry codes (`seed.py:165,170`), but `mcp_server/uv.lock` was frozen to **omh-shim 1.2.0**, which predates those schemas. CI installs the lock with `uv sync --frozen`, so it gets 1.2.0 and fails.

It surfaced now because the CI is path-filtered to `mcp_server/**` and hadn't run since the drift landed (the README PR #542 was the first trigger). It is independent of any of those doc changes.

## Fix

- **omh-shim 1.3.0 ships both schemas** (verified in the published wheel). Bump the floor pin `>=1.2.0` → `>=1.3.0` and relock `uv.lock` to 1.3.0 (`uv lock --upgrade-package omh-shim` — only omh-shim changes, no transitive churn).
- **Add a Dependabot `uv` entry for `/mcp_server`.** The existing `dependabot.yaml` covered only the root `pip` project, `github-actions`, and the frontend npm project — nothing watched the uv subproject, which is why the lock drifted silently. omh-shim is first-party and adds OMH schemas frequently; this keeps the lock current, and the drift-guard test gates every bump.

## Verification

Reproduced CI locally (`uv sync --frozen --extra dev`):

- `test_omh_registry.py`: **9 passed** (was 1 failing)
- full unit suite: **155 passed**
- `ruff check src tests`: clean
- `dependabot.yaml`: valid YAML

## Note

Once merged, I'll rebase the README PR (#542) onto main so its `mcp_server` CI picks up the fixed lock and goes green.