### PR TITLE
feat: add Docker dev mode with live code reload

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+# Dev override: live code reload for the web service.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# Mounts the repo into the container and runs Django's autoreloading dev server
+# instead of gunicorn, so backend edits apply on the next request with no rebuild.
+# The base image still bakes code in for production (plain `docker compose up`).
+services:
+  web:
+    # Mount the working tree over /code so host edits are seen live. Dependencies are
+    # installed into the system site-packages (not /code), so they are not shadowed;
+    # a Pipfile change still needs an image rebuild.
+    volumes:
+      - .:/code
+    command: >
+      sh -c "python manage.py migrate --noinput &&
+             python manage.py runserver 0.0.0.0:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  db:
+    image: postgres:17-alpine
+    container_name: jhe-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: jheuser
+      POSTGRES_PASSWORD: jhepassword
+      POSTGRES_DB: jhe_dev
+    ports:
+      - "5433:5432"
+    volumes:
+      - jhe_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U jheuser -d jhe_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: jhe-web
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      SITE_URL: http://localhost:8001
+      OW_API_URL: http://host.docker.internal:8000
+      DEBUG: "True"
+    ports:
+      - "8001:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      sh -c "python manage.py migrate --noinput &&
+             gunicorn --bind :8000 --workers 2 jhe.wsgi"
+
+volumes:
+  jhe_db_data:


### PR DESCRIPTION
Add docker-compose.dev.yml overriding the web service to volume-mount the repo and run runserver autoreload, so backend and static edits apply without an image rebuild. Commit the base docker-compose.yml. Production image/command unchanged.

Run with: docker compose -f docker-compose.yml -f docker-compose.dev.yml up