### PR TITLE
fix: client-side required validation on client form (#565)

### DIFF
--- a/core/static/clients/jhe-admin/js/client-jhe-admin.js
+++ b/core/static/clients/jhe-admin/js/client-jhe-admin.js
@@ -1968,7 +1968,27 @@ async function renderClients(queryParams) {
   return content(renderParams);
 }
 
+function validateClientForm() {
+  const errors = [];
+  const name = document.getElementById("clientName")?.value?.trim() || "";
+  const clientId =
+    document.getElementById("clientClientId")?.value?.trim() || "";
+  const invitationUrl =
+    document.getElementById("clientInvitationUrl")?.value?.trim() || "";
+  if (!name) errors.push("Name is required.");
+  if (!clientId) errors.push("Client ID is required.");
+  if (!invitationUrl) {
+    errors.push("Invitation URL is required.");
+  } else if (!invitationUrl.includes("CODE")) {
+    errors.push("Invitation URL must contain the CODE placeholder.");
+  }
+  return errors;
+}
+
 async function createClient() {
+  clearModalValidationErrors();
+  const errors = validateClientForm();
+  if (errors.length) return displayModalValidationError(errors);
   const clientRecord = {
     name: document.getElementById("clientName").value,
     invitationUrl: document.getElementById("clientInvitationUrl").value,
@@ -1979,6 +1999,9 @@ async function createClient() {
 }
 
 async function updateClient(id) {
+  clearModalValidationErrors();
+  const errors = validateClientForm();
+  if (errors.length) return displayModalValidationError(errors);
   const clientRecord = {
     name: document.getElementById("clientName").value,
     invitationUrl: document.getElementById("clientInvitationUrl").value,

--- a/core/templates/clients/jhe_admin/components/clients.html
+++ b/core/templates/clients/jhe_admin/components/clients.html
@@ -114,7 +114,7 @@
                 {{/unless}}
                 <div class="mb-3">
                   <label for="clientName" class="form-label"
-                    >Name</label
+                    >Name*</label
                   >
                   <input
                     type="text"
@@ -125,7 +125,7 @@
                 </div>
                 <div class="mb-3">
                   <label for="clientInvitationUrl" class="form-label"
-                    >Invitation URL<br/><small>Use the variable <code>CODE</code> to insert authorization code<br/>Eg. <code>https://example.com?invitation=CODE</code></small></label
+                    >Invitation URL*<br/><small>Use the variable <code>CODE</code> to insert authorization code<br/>Eg. <code>https://example.com?invitation=CODE</code></small></label
                   >
                   <input
                     type="text"
@@ -136,7 +136,7 @@
                 </div>
                 <div class="mb-3">
                   <label for="clientClientId" class="form-label"
-                    >Client ID</label
+                    >Client ID*</label
                   >
                   <input
                     type="text"


### PR DESCRIPTION
Add validateClientForm() wired into createClient/updateClient: Name, Client ID, and Invitation URL required, and Invitation URL must contain the CODE placeholder. Errors show in the existing modal .validationError banner via displayModalValidationError(). Mark the three labels with *.