### PR TITLE
fix: client-side required validation on data source form (#566)

### DIFF
--- a/core/static/clients/jhe-admin/js/client-jhe-admin.js
+++ b/core/static/clients/jhe-admin/js/client-jhe-admin.js
@@ -2121,7 +2121,19 @@ async function renderDataSources(queryParams) {
   return content(renderParams);
 }
 
+function validateDataSourceForm() {
+  const errors = [];
+  const name = document.getElementById("dataSourceName")?.value?.trim() || "";
+  const type = document.getElementById("dataSourceType")?.value?.trim() || "";
+  if (!name) errors.push("Name is required.");
+  if (!type) errors.push("Type is required.");
+  return errors;
+}
+
 async function createDataSource() {
+  clearModalValidationErrors();
+  const errors = validateDataSourceForm();
+  if (errors.length) return displayModalValidationError(errors);
   const dataSourceRecord = {
     name: document.getElementById("dataSourceName").value || null,
     type: document.getElementById("dataSourceType").value,
@@ -2131,6 +2143,9 @@ async function createDataSource() {
 }
 
 async function updateDataSource(id) {
+  clearModalValidationErrors();
+  const errors = validateDataSourceForm();
+  if (errors.length) return displayModalValidationError(errors);
   const dataSourceRecord = {
     name: document.getElementById("dataSourceName").value || null,
     type: document.getElementById("dataSourceType").value || null,

--- a/core/templates/clients/jhe_admin/components/data_sources.html
+++ b/core/templates/clients/jhe_admin/components/data_sources.html
@@ -88,6 +88,7 @@
           ></button>
         </div>
         <div class="modal-body">
+          <div class="alert alert-warning validationError" style="display: none" role="alert"></div>
           <div class="container-fluid">
             {{#if delete}}
               <div class="alert alert-danger" role="alert">
@@ -113,7 +114,7 @@
                 {{/unless}}
                 <div class="mb-3">
                   <label for="dataSourceName" class="form-label"
-                    >Name</label
+                    >Name*</label
                   >
                   <input
                     type="text"
@@ -124,7 +125,7 @@
                 </div>
                 <div class="mb-3">
                   <label for="dataSourceType" class="form-label"
-                    >Type</label
+                    >Type*</label
                   >
                   <select id="dataSourceType" class="form-select">
                   {{#dataSourceRecord.typeSelect}}


### PR DESCRIPTION
Add validateDataSourceForm() wired into createDataSource/updateDataSource: Name and Type required before submit. Errors show in a new modal .validationError banner via displayModalValidationError(). Mark the Name and Type labels with *.