### PR TITLE
fix: order Practitioner and JheSetting list querysets to fix UnorderedObjectListWarning (#589)

### DIFF
--- a/core/views/jhe_setting.py
+++ b/core/views/jhe_setting.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class JheSettingViewSet(ModelViewSet):
     serializer_class = JheSettingSerializer
-    queryset = JheSetting.objects.all()
+    queryset = JheSetting.objects.all().order_by("id")
     permission_classes = [IsAuthenticated, IsSuperUser]
 
     # def get_permissions(self):

--- a/core/views/practitioner.py
+++ b/core/views/practitioner.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 class PractitionerViewSet(ModelViewSet):
     serializer_class = PractitionerSerializer
-    queryset = Practitioner.objects.all()
+    queryset = Practitioner.objects.all().order_by("id")
     permission_classes = [IsAuthenticated, IsSuperUser]
 
     def create(self, request, *args, **kwargs):

--- a/tests/backend/test_jhe_setting_viewset.py
+++ b/tests/backend/test_jhe_setting_viewset.py
@@ -1,0 +1,21 @@
+from rest_framework.test import APIClient
+
+from core.models import JheSetting
+
+
+def test_list_settings_pagination_is_ordered(superuser, recwarn):
+    # The settings list is paginated, so its queryset must have a stable order;
+    # otherwise DRF emits an UnorderedObjectListWarning and pages can skip/repeat rows (issue #589).
+    for i in range(15):
+        setting = JheSetting(key=f"order.test.{i:02d}", value_type="string")
+        setting.set_value("string", "v")
+        setting.save()
+    api_client = APIClient()
+    api_client.default_format = "json"
+    api_client.force_authenticate(superuser)
+    r = api_client.get("/api/v1/jhe_settings", {"pageSize": 10})
+    assert r.status_code == 200, r.text
+    unordered = [w for w in recwarn.list if w.category.__name__ == "UnorderedObjectListWarning"]
+    assert not unordered, [str(w.message) for w in unordered]
+    ids = [row["id"] for row in r.json()["results"]]
+    assert ids == sorted(ids)

--- a/tests/backend/test_practitioner_viewset.py
+++ b/tests/backend/test_practitioner_viewset.py
@@ -70,6 +70,22 @@ def test_list_practitioners(superuser):
     assert len(practitioners) >= 0
 
 
+def test_list_practitioners_pagination_is_ordered(superuser, recwarn):
+    # The practitioner list is paginated, so its queryset must have a stable order;
+    # otherwise DRF emits an UnorderedObjectListWarning and pages can skip/repeat rows (issue #589).
+    for i in range(15):
+        _make_practitioner(f"prac-order-{i:02d}@example.org")
+    api_client = APIClient()
+    api_client.default_format = "json"
+    api_client.force_authenticate(superuser)
+    r = api_client.get("/api/v1/practitioners", {"pageSize": 10})
+    assert r.status_code == 200, r.text
+    unordered = [w for w in recwarn.list if w.category.__name__ == "UnorderedObjectListWarning"]
+    assert not unordered, [str(w.message) for w in unordered]
+    ids = [row["id"] for row in r.json()["results"]]
+    assert ids == sorted(ids)
+
+
 def test_list_practitioners_no_auth(user):
     api_client = APIClient()
     r = api_client.get("/api/v1/practitioners")


### PR DESCRIPTION
Adds a stable `.order_by("id")` to the Practitioner and JheSetting REST list querysets so pagination is deterministic and no longer emits UnorderedObjectListWarning. Mirrors the Patient REST fix (#567). Includes a regression test per model. Full backend suite green; verified at runtime (both lists load, server log shows 0 warnings). Closes #589.