### PR TITLE
fix: add #pageNotice element so jhe-admin batch-action notices render (#574)

### DIFF
--- a/core/templates/clients/jhe_admin/components/body.html
+++ b/core/templates/clients/jhe_admin/components/body.html
@@ -67,6 +67,7 @@
       </div>
       <div id="mainContent" class="col p-3 overflow-auto h-100">
         <div class="alert alert-danger text-center" role="alert" id="errorAlert" style="display: none"></div>
+        <div id="pageNotice" style="display: none"></div>
         {{{mainContent}}}
       </div>
   </div>


### PR DESCRIPTION
Adds the missing #pageNotice element next to #errorAlert in body.html. The displayPageNotice/clearPageNotice helpers and all batch-action call sites already shipped in #563, but without the DOM element the 3 batch-action 'nothing selected' notices silently no-op'd. This completes #574. Verified manually: all 3 guards (add-to-study, remove-from-study, practitioners batch) now show the in-place notice. collectstatic succeeds; backend suite green. Closes #574.