### PR TITLE
fix: wrap OMH schema validation errors as Django ValidationError in Observation.clean() (#527)

### DIFF
--- a/core/models/observation.py
+++ b/core/models/observation.py
@@ -4,6 +4,7 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import BadRequest, PermissionDenied
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models
 from django.db.models import F, Q
 from django.db.utils import IntegrityError
@@ -323,8 +324,11 @@ class Observation(models.Model):
                 ).read_text()
             )
             validate_with_registry(instance=omh_data.get("body"), schema=body_schema)
-        except Exception as error:
-            raise error
+        except ValidationError as error:
+            # Re-raise OMH schema failures as a Django ValidationError keyed to omh_data so the
+            # admin renders an inline field error instead of a 500 (issue #527). The API path
+            # (save -> clean) still raises here; the FHIR view maps it to a 422.
+            raise DjangoValidationError({"omh_data": error.message}) from error
 
     def save(self, *args, **kwargs):
         self.clean()

--- a/tests/backend/test_observation_admin.py
+++ b/tests/backend/test_observation_admin.py
@@ -1,0 +1,55 @@
+"""
+Issue #527: saving an Observation whose omh_data fails OMH schema validation must
+re-render the admin form with an inline error on the omh_data field, not raise a 500.
+"""
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from core.models import CodeableConcept, Observation
+
+JheUser = get_user_model()
+
+
+@pytest.fixture
+def admin_client(db, client):
+    su = JheUser.objects.create_superuser(email="admin@example.org", password="pw")
+    client.force_login(su)
+    return client
+
+
+@pytest.fixture
+def patient(db):
+    user = JheUser.objects.create_user(email="obs-patient@example.org", password="x", user_type="patient")
+    return user.patient
+
+
+@pytest.fixture
+def heart_rate_concept(db):
+    concept, _ = CodeableConcept.objects.update_or_create(
+        coding_system="https://w3id.org/openmhealth",
+        coding_code="omh:heart-rate:2.0",
+        text="omh:heart-rate:2.0",
+    )
+    return concept
+
+
+def test_admin_add_invalid_omh_data_renders_field_error_not_500(admin_client, patient, heart_rate_concept):
+    url = reverse("admin:core_observation_add")
+    # Valid JSON, but the header/body fail the OMH schema -> Observation.clean() raises.
+    r = admin_client.post(
+        url,
+        {
+            "subject_patient": patient.id,
+            "codeable_concept": heart_rate_concept.id,
+            "omh_data": json.dumps({"header": {}, "body": {}}),
+            "status": "final",
+        },
+    )
+    # Form re-renders (200), nothing is saved, and the error is keyed to the omh_data field.
+    assert r.status_code == 200
+    assert Observation.objects.count() == 0
+    assert "omh_data" in r.context["adminform"].form.errors


### PR DESCRIPTION
Observation.clean() caught jsonschema.ValidationError and re-raised it as-is, so saving schema-invalid omh_data via the Django admin returned an HTTP 500 (jsonschema traceback under DEBUG). This catches it and re-raises a Django ValidationError keyed to omh_data, so the admin re-renders the form with an inline field error. The API path is unchanged: the FHIR write view already maps non-DRF errors to 422, and a Django ValidationError is not a DRF ValidationError, so it still 422s. Includes an admin regression test. Verified manually: invalid payloads (missing header field, missing body field, wrong type, wrong shape) all show inline errors; valid data saves; zero 500s. Backend suite green. Closes #527.