### PR TITLE
feat: add patient User ID to Observations display (jhe-admin + Django admin) (#525)

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -102,7 +102,7 @@ class DataSourceAdmin(admin.ModelAdmin):
 
 @admin.register(Observation)
 class ObservationAdmin(admin.ModelAdmin):
-    list_display = ("id", "patient_name", "scope", "source_name", "status", "ow_key_short", "last_updated")
+    list_display = ("id", "patient_name", "user_id", "scope", "source_name", "status", "ow_key_short", "last_updated")
     search_fields = ("ow_key", "subject_patient__name_family", "subject_patient__name_given")
     list_filter = ("status", "codeable_concept", "data_source")
     raw_id_fields = ("subject_patient", "codeable_concept", "data_source")
@@ -111,6 +111,11 @@ class ObservationAdmin(admin.ModelAdmin):
     def patient_name(self, obj):
         p = obj.subject_patient
         return f"{p.name_family}, {p.name_given}"
+
+    @admin.display(description="User ID")
+    def user_id(self, obj):
+        # The patient's JHE-generated account id (jheUserId), distinct from the Patient record id.
+        return obj.subject_patient.jhe_user_id
 
     @admin.display(description="Scope")
     def scope(self, obj):

--- a/core/models/observation.py
+++ b/core/models/observation.py
@@ -107,6 +107,7 @@ class Observation(models.Model):
                 coding_text=F("codeable_concept__text"),
                 patient_name_family=F("subject_patient__name_family"),
                 patient_name_given=F("subject_patient__name_given"),
+                jhe_user_id=F("subject_patient__jhe_user_id"),
             )
             .distinct()
             .order_by("-last_updated")

--- a/core/serializers/observation.py
+++ b/core/serializers/observation.py
@@ -11,6 +11,7 @@ from core.models import Observation
 class ObservationSerializer(serializers.ModelSerializer):
     patient_name_family = serializers.CharField()
     patient_name_given = serializers.CharField()
+    jhe_user_id = serializers.IntegerField()
     coding_system = serializers.CharField()
     coding_code = serializers.CharField()
     coding_text = serializers.CharField()
@@ -22,6 +23,7 @@ class ObservationSerializer(serializers.ModelSerializer):
             "subject_patient_id",
             "patient_name_family",
             "patient_name_given",
+            "jhe_user_id",
             "codeable_concept_id",
             "coding_system",
             "coding_code",

--- a/core/templates/clients/jhe_admin/components/observations.html
+++ b/core/templates/clients/jhe_admin/components/observations.html
@@ -68,6 +68,7 @@
         <th scope="col">ID</th>
         <th scope="col">Scope</th>
         <th scope="col">Patient</th>
+        <th scope="col">User ID</th>
         <th scope="col">Transaction Time</th>
         <th scope="col">Data</th>
       </tr>
@@ -80,11 +81,17 @@
           <td>{{id}}</td>
           <td>{{codingText}}</td>
           <td>{{patientNameFamily}}, {{patientNameGiven}}</td>
+          <td>{{jheUserId}}</td>
           <td>{{lastUpdated}}</td>
           <td><pre>{{omhData}}</pre></td>
         </tr>
       {{/observations}}
     </tbody>
   </table>
+  <div class="form-text">
+    <strong>ID</strong> is the JHE-generated Patient record id.
+    <strong>User ID</strong> is the JHE-generated account id (jheUserId) for the patient's login.
+    A patient's External ID, set by whoever created the patient, is shown on the Patient record.
+  </div>
 </script>
 {% endverbatim %}

--- a/tests/backend/test_observation_admin_display.py
+++ b/tests/backend/test_observation_admin_display.py
@@ -1,0 +1,26 @@
+"""Issue #525: the Django admin Observations changelist shows the patient's JHE User ID."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from .utils import Code, add_observations
+
+JheUser = get_user_model()
+
+
+@pytest.fixture
+def admin_client(db, client):
+    su = JheUser.objects.create_superuser(email="admin-525@example.org", password="pw")
+    client.force_login(su)
+    return client
+
+
+def test_observation_changelist_shows_user_id(admin_client, patient):
+    add_observations(patient=patient, code=Code.HeartRate, n=2)
+    url = reverse("admin:core_observation_changelist")
+    r = admin_client.get(url)
+    assert r.status_code == 200
+    # the "User ID" column header and the patient's jhe_user_id are both rendered
+    assert b"User ID" in r.content
+    assert str(patient.jhe_user_id).encode() in r.content

--- a/tests/backend/test_observation_viewset.py
+++ b/tests/backend/test_observation_viewset.py
@@ -79,6 +79,16 @@ def test_observation_pagination(hr_study, patient, api_client, get_observations)
     assert link_rels == ["self", "previous"]
 
 
+def test_observation_list_includes_user_id(api_client, patient, hr_study):
+    # The REST observations list exposes the patient's JHE User ID (jheUserId) so it can be
+    # shown in the jhe-admin and Django admin Observations displays (issue #525).
+    add_observations(patient=patient, code=Code.HeartRate, n=3)
+    results = fetch_paginated(api_client, "/api/v1/observations", {"patient_id": patient.id, "pageSize": 10})
+    assert results
+    for row in results:
+        assert row["jheUserId"] == patient.jhe_user_id
+
+
 def test_observation_limit(hr_study, patient, api_client, get_observations):
     """Test a large query with lots of entries"""
     n = 10_100


### PR DESCRIPTION
Adds the patient's JHE User ID (jheUserId) to the Observations display on both surfaces: a new 'User ID' column in the jhe-admin SPA Observations table (plus a short hint defining Patient ID vs User ID vs External ID), and a User ID column in the Django admin Observations changelist. Backend: annotate jhe_user_id on the list queryset and expose it on ObservationSerializer (renders as jheUserId via the camel-case renderer). Includes an API regression test and an admin changelist test. Verified manually on both surfaces. Closes #525.