### PR TITLE
test: lock query-param whitelist so unknown params don't 500 (#226)

### DIFF
--- a/tests/backend/test_patient_viewset.py
+++ b/tests/backend/test_patient_viewset.py
@@ -118,6 +118,17 @@ def test_list_patients(api_client, organization):
     assert len(patients) == n
 
 
+def test_patient_list_ignores_unknown_query_params(api_client, organization):
+    # Unknown query params (e.g. ?email=) must be dropped, not forwarded to
+    # for_practitioner_organization_study where they 500 with an unexpected-keyword
+    # TypeError (issue #226). Supported filters still work.
+    add_patients(3, organization)
+    r = api_client.get("/api/v1/patients", {"email": "nobody@example.org", "bogus": "x"})
+    assert r.status_code == 200, r.text
+    r2 = api_client.get("/api/v1/patients", {"organization_id": organization.id})
+    assert r2.status_code == 200, r2.text
+
+
 def test_create_delete(api_client, organization):
     email = "testcreate-patient@example.com"
     r = api_client.post(


### PR DESCRIPTION
Adds a regression test asserting the patient list endpoint ignores unknown query params (e.g. ?email=) and returns 200, not a 500. The original 500 (TypeError: unexpected keyword argument) was already resolved when pagination moved out of admin_pagination.py into the viewset's supported_query_params whitelist; this test locks that behavior so it can't regress. Verified the test is a real guard: temporarily bypassing the whitelist reproduces the exact ticket TypeError. Closes #226.