### PR TITLE
feat: expose patient User ID as subject.identifier on FHIR Observation (#602)

### DIFF
--- a/core/fhir/fhir_config.json
+++ b/core/fhir/fhir_config.json
@@ -58,7 +58,11 @@
         "coding": "Observation.codeable_concepts"
       },
       "subject": {
-        "reference": "'Patient/' + Observation.subject_patient"
+        "reference": "'Patient/' + Observation.subject_patient",
+        "identifier": {
+          "system": "'https://jupyterhealth.org/fhir/identifier/jhe-user-id'",
+          "value": "Observation.subject_patient.jhe_user_id"
+        }
       },
       "valueAttachment": {
         "contentType": "'application/json'",

--- a/core/serializers/observation.py
+++ b/core/serializers/observation.py
@@ -57,6 +57,11 @@ class FHIRObservationSerializer(serializers.Serializer):
         attachment = as_dict.get("valueAttachment")
         if attachment and isinstance(attachment.get("data"), (dict, list)):
             attachment["data"] = base64.b64encode(json.dumps(attachment["data"]).encode("utf-8")).decode("ascii")
+        # subject.identifier carries the patient's jheUserId (issue #602). The mapping yields the
+        # raw integer id; FHIR Identifier.value is a string, so coerce it here.
+        identifier = (as_dict.get("subject") or {}).get("identifier")
+        if identifier and "value" in identifier:
+            identifier["value"] = str(identifier["value"])
         return as_dict
 
 

--- a/tests/backend/test_fhir_observation_subject_identifier.py
+++ b/tests/backend/test_fhir_observation_subject_identifier.py
@@ -1,0 +1,42 @@
+"""Issue #602: the FHIR Observation output carries the patient's jheUserId as a
+subject.identifier, distinct from subject.reference (which is the Patient record id)."""
+
+from fhir.resources.observation import Observation as FHIRObservation
+
+from core.models import JheUser, Observation, Patient
+from core.serializers import FHIRObservationSerializer
+
+from .utils import Code, add_observations
+
+JHE_USER_ID_SYSTEM = "https://jupyterhealth.org/fhir/identifier/jhe-user-id"
+
+
+def _render_one(patient):
+    add_observations(patient=patient, code=Code.HeartRate, n=1)
+    obs = Observation.objects.filter(subject_patient=patient).first()
+    return FHIRObservationSerializer(obs).data
+
+
+def test_fhir_observation_exposes_jhe_user_id_as_subject_identifier(db):
+    user = JheUser.objects.create_user(email="obs-602@example.org", password="x", user_type="patient")
+    patient = user.patient
+
+    data = _render_one(patient)
+
+    assert data["subject"]["reference"] == f"Patient/{patient.id}"
+    identifier = data["subject"]["identifier"]
+    assert identifier["system"] == JHE_USER_ID_SYSTEM
+    # FHIR identifier.value is a string; the value is the jheUserId (account id), not the record id.
+    assert identifier["value"] == str(patient.jhe_user_id)
+    assert isinstance(identifier["value"], str)
+    # The whole resource must remain valid FHIR R5.
+    FHIRObservation.parse_obj(data)
+
+
+def test_fhir_observation_omits_identifier_when_patient_has_no_user(db):
+    patient = Patient.objects.create(name_family="No", name_given="User")
+
+    data = _render_one(patient)
+
+    assert data["subject"]["reference"] == f"Patient/{patient.id}"
+    assert "identifier" not in data["subject"]

--- a/tests/backend/test_fhir_resource_view.py
+++ b/tests/backend/test_fhir_resource_view.py
@@ -210,7 +210,12 @@ def test_observation_read_by_id(api_client, patient, hr_study):
     body = r.json()
     assert body["resourceType"] == "Observation"
     assert body["id"] == str(obs.id)
-    assert body["subject"] == {"reference": f"Patient/{patient.id}"}
+    assert body["subject"]["reference"] == f"Patient/{patient.id}"
+    # subject.identifier carries the patient's jheUserId, distinct from the record id (issue #602)
+    assert body["subject"]["identifier"] == {
+        "system": "https://jupyterhealth.org/fhir/identifier/jhe-user-id",
+        "value": str(patient.jhe_user_id),
+    }
 
 
 def test_observation_read_by_id_not_found(api_client, patient, hr_study):

--- a/tests/backend/test_observation_viewset.py
+++ b/tests/backend/test_observation_viewset.py
@@ -147,7 +147,8 @@ def test_observation_upload_bundle(api_client, device, hr_study, patient, get_ob
     resource_out = results[0]["resource"]
     resource_in = entries[0]["resource"]
 
-    assert resource_in["subject"] == resource_out["subject"]
+    # subject.reference round-trips; the output also carries subject.identifier (jheUserId, issue #602)
+    assert resource_out["subject"]["reference"] == resource_in["subject"]["reference"]
     value_attachment_in = json.loads(base64.b64decode(resource_in["valueAttachment"]["data"]).decode())
     value_attachment_out = json.loads(base64.b64decode(resource_out["valueAttachment"]["data"]).decode())
     assert value_attachment_out["body"] == value_attachment_in["body"]
@@ -214,7 +215,8 @@ def test_observation_upload(api_client, device, hr_study, patient, get_observati
     resource_out = results[0]["resource"]
     resource_in = resource
 
-    assert resource_in["subject"] == resource_out["subject"]
+    # subject.reference round-trips; the output also carries subject.identifier (jheUserId, issue #602)
+    assert resource_out["subject"]["reference"] == resource_in["subject"]["reference"]
     value_attachment_in = json.loads(base64.b64decode(resource_in["valueAttachment"]["data"]).decode())
     value_attachment_out = json.loads(base64.b64decode(resource_out["valueAttachment"]["data"]).decode())
     assert value_attachment_out["body"] == value_attachment_in["body"]


### PR DESCRIPTION
Adds the patient jheUserId as subject.identifier on the FHIR R5 Observation output (subject.reference stays the Patient record id). Mapping + a string coercion in FHIRObservationSerializer; pruned when the patient has no account. Tests added/updated. Closes #602.