### PR TITLE
feat: surface the dashboard access token on the Profile page (#245)

### DIFF
--- a/core/static/clients/jhe-admin/js/client-jhe-admin.js
+++ b/core/static/clients/jhe-admin/js/client-jhe-admin.js
@@ -2333,6 +2333,22 @@ async function deletePractitionerClient(id) {
   if (await apiRequest("DELETE", `practitioner_clients/${id}`)) await navReturnFromCrud();
 }
 
+// Reveal / copy the current dashboard session access token (the OIDC Bearer used for manual
+// API calls, e.g. JupyterHealth Client). Previously only reachable via the superuser Debug
+// page's "Get User" (issue #245).
+async function showDashboardAccessToken() {
+  const user = await userManager.getUser();
+  document.getElementById("dashboardAccessToken").textContent =
+    user?.access_token || "No active session token - please log in again.";
+}
+
+async function copyDashboardAccessToken(btn) {
+  const user = await userManager.getUser();
+  if (!user?.access_token) return showDashboardAccessToken();
+  await navigator.clipboard.writeText(user.access_token);
+  btn.disabled = true;
+}
+
 // Exchange the API key (base64 of client_id:client_secret, used as-is for HTTP Basic auth)
 // for an access token via the client-credentials grant, and echo the full request/response
 // into #testPractitonerApiKeyOutput so the practitioner can see a working example.

--- a/core/templates/clients/jhe_admin/components/profile.html
+++ b/core/templates/clients/jhe_admin/components/profile.html
@@ -27,6 +27,26 @@
     </tbody>
   </table>
 
+  <h5 class="mt-5">Dashboard Access Token</h5>
+  <p class="text-muted small mb-2">
+    A short-lived OAuth access token for this dashboard session. Use it to call the API manually
+    (for example from JupyterHealth Client) when not launched via JupyterHub. It expires when the
+    session ends; for long-lived programmatic access, create an API Key below.
+  </p>
+  <div class="d-flex align-items-center gap-2 mb-2">
+    <code id="dashboardAccessToken" class="p-2 bg-light rounded text-break flex-grow-1">Click Show to reveal your access token</code>
+    <button
+      type="button"
+      class="btn btn-sm btn-outline-secondary"
+      onclick="showDashboardAccessToken()"
+    >Show</button>
+    <button
+      type="button"
+      class="btn btn-sm btn-outline-primary"
+      onclick="copyDashboardAccessToken(this)"
+    ><i class="bi bi-clipboard"></i></button>
+  </div>
+
   <h5 class="mt-5">Admin API Access</h5>
   <table class="table table-striped">
     <thead>

--- a/tests/backend/test_profile_access_token.py
+++ b/tests/backend/test_profile_access_token.py
@@ -1,0 +1,16 @@
+"""Issue #245: the dashboard session access token must be retrievable from a
+discoverable place (the Profile page), not only the superuser-only Debug page.
+
+The token itself is client-side (OIDC userManager), so this asserts the Profile
+template ships the access-token section and its copy affordance."""
+
+from django.urls import reverse
+
+
+def test_profile_page_exposes_dashboard_access_token_section(db, client):
+    resp = client.get(reverse("portal", kwargs={"path": ""}))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    # The Profile page carries a copyable dashboard access token.
+    assert 'id="dashboardAccessToken"' in html
+    assert "copyDashboardAccessToken(" in html


### PR DESCRIPTION
Adds a 'Dashboard Access Token' section to the Profile page so any user can copy their current session token for manual API use (previously only on the superuser Debug page). Closes #245.