### PR TITLE
feat: support _id and _lastUpdated (ge/le/gt/lt) FHIR search params (#585)

### DIFF
--- a/core/views/fhir.py
+++ b/core/views/fhir.py
@@ -24,7 +24,10 @@ import uuid
 
 from django.core.exceptions import BadRequest as DjangoBadRequest
 from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.utils import IntegrityError
+from django.utils import timezone
+from django.utils.dateparse import parse_date, parse_datetime
 from rest_framework import status as http_status
 from rest_framework.exceptions import APIException, MethodNotAllowed, NotFound
 from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
@@ -96,6 +99,53 @@ def _canonical_search_kwargs(request):
         kwargs["coding_system"] = system
         kwargs["coding_code"] = value
     return kwargs
+
+
+# US Core date-comparator prefixes -> Django ORM lookups (issue #585).
+_DATE_COMPARATORS = {"ge": "gte", "le": "lte", "gt": "gt", "lt": "lt"}
+
+
+def _last_updated_values(request):
+    # The camel-case parser may snake-case the query key, so accept both spellings.
+    return request.GET.getlist("_lastUpdated") + request.GET.getlist("_last_updated")
+
+
+def apply_common_search_filters(queryset, request):
+    """Apply the resource-agnostic US Core search params ``_id`` and ``_lastUpdated`` (issue #585).
+
+    Works on any search queryset: every mapped model and FhirAuxResource exposes ``id`` and
+    ``last_updated``. ``_id`` is an exact match (an id of the wrong shape for this store yields no
+    rows, so a UUID id matches only the aux source and an integer id only the mapped source).
+    ``_lastUpdated`` supports the ``ge``/``le``/``gt``/``lt`` comparators, or a bare date meaning
+    that whole calendar day; repeated ``_lastUpdated`` params AND together to express a range.
+    """
+    resource_id = request.GET.get("_id")
+    if resource_id:
+        try:
+            queryset.model._meta.pk.to_python(resource_id)
+        except (ValueError, TypeError, DjangoValidationError):
+            return queryset.none()
+        queryset = queryset.filter(pk=resource_id)
+
+    for raw in _last_updated_values(request):
+        comparator = _DATE_COMPARATORS.get(raw[:2])
+        value = raw[2:] if comparator else raw
+        dt = parse_datetime(value)
+        if dt is not None:
+            # A datetime value: compare against the instant (made aware to avoid naive warnings).
+            if timezone.is_naive(dt):
+                dt = timezone.make_aware(dt)
+            lookup = f"last_updated__{comparator}" if comparator else "last_updated__date"
+            queryset = queryset.filter(**{lookup: (dt if comparator else dt.date())})
+            continue
+        day = parse_date(value)
+        if day is None:
+            raise DRFValidationError(f"Invalid _lastUpdated value: '{raw}'.")
+        # A date-only value: compare the date part (day-granular, matches FHIR date precision
+        # and sidesteps naive-datetime warnings on the DateTimeField).
+        lookup = f"last_updated__date__{comparator}" if comparator else "last_updated__date"
+        queryset = queryset.filter(**{lookup: day})
+    return queryset
 
 
 class MappedResourceHandler:
@@ -459,12 +509,12 @@ class FHIRResourceView(APIView):
         sources = []
         if is_mapped_resource(resource) and "search" in mapped_interactions(resource):
             handler = self._mapped_handler(resource)
-            sources.append((handler.search(), handler.serialize))
+            sources.append((apply_common_search_filters(handler.search(), self.request), handler.serialize))
         if is_aux_resource(resource) and "search" in aux_interactions(resource):
             # Reads don't require the source header: the aux handler scopes to the source's
             # patient when it is present, else to everything the user can access.
             handler = self._aux_handler(resource)
-            sources.append((handler.search(), handler.serialize))
+            sources.append((apply_common_search_filters(handler.search(), self.request), handler.serialize))
 
         paginator = FHIRBundlePagination()
         page = paginator.paginate_queryset(ConcatenatedResults(sources), self.request, view=self)

--- a/tests/backend/test_fhir_search_common_params.py
+++ b/tests/backend/test_fhir_search_common_params.py
@@ -1,0 +1,83 @@
+"""Issue #585 (first slice): resource-agnostic US Core search params on the FHIR endpoint -
+`_id` (exact) and `_lastUpdated` with ge/le/gt/lt comparators (and ranges)."""
+
+import datetime
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from core.models import Observation
+
+from .utils import Code, add_observations
+
+
+@pytest.fixture
+def api(user):
+    client = APIClient()
+    client.default_format = "json"
+    client.force_authenticate(user)  # practitioner who shares the patient's organization
+    return client
+
+
+def _bundle_ids(response):
+    return {entry["resource"]["id"] for entry in response.json().get("entry", [])}
+
+
+def _set_last_updated(obs_id, dt):
+    # .update() bypasses auto_now so we can pin a known timestamp.
+    Observation.objects.filter(id=obs_id).update(last_updated=dt)
+
+
+def test_search_last_updated_ge(api, patient):
+    add_observations(patient=patient, code=Code.HeartRate, n=2)
+    old, new = sorted(Observation.objects.filter(subject_patient=patient), key=lambda o: o.id)
+    _set_last_updated(old.id, timezone.make_aware(datetime.datetime(2020, 1, 1)))
+    _set_last_updated(new.id, timezone.make_aware(datetime.datetime(2024, 6, 1)))
+
+    r = api.get("/FHIR/R5/Observation", {"_lastUpdated": "ge2023-01-01"})
+
+    assert r.status_code == 200, r.text
+    ids = _bundle_ids(r)
+    assert str(new.id) in ids
+    assert str(old.id) not in ids
+
+
+def test_search_last_updated_range(api, patient):
+    add_observations(patient=patient, code=Code.HeartRate, n=3)
+    a, b, c = sorted(Observation.objects.filter(subject_patient=patient), key=lambda o: o.id)
+    _set_last_updated(a.id, timezone.make_aware(datetime.datetime(2019, 1, 1)))
+    _set_last_updated(b.id, timezone.make_aware(datetime.datetime(2022, 6, 1)))
+    _set_last_updated(c.id, timezone.make_aware(datetime.datetime(2025, 1, 1)))
+
+    r = api.get("/FHIR/R5/Observation", {"_lastUpdated": ["ge2021-01-01", "le2023-01-01"]})
+
+    assert r.status_code == 200, r.text
+    assert _bundle_ids(r) == {str(b.id)}
+
+
+def test_search_by_id(api, patient):
+    add_observations(patient=patient, code=Code.HeartRate, n=2)
+    target = Observation.objects.filter(subject_patient=patient).first()
+
+    r = api.get("/FHIR/R5/Observation", {"_id": str(target.id)})
+
+    assert r.status_code == 200, r.text
+    assert _bundle_ids(r) == {str(target.id)}
+
+
+def test_search_invalid_id_returns_empty_not_500(api, patient):
+    add_observations(patient=patient, code=Code.HeartRate, n=1)
+
+    r = api.get("/FHIR/R5/Observation", {"_id": "not-an-integer"})
+
+    assert r.status_code == 200, r.text
+    assert _bundle_ids(r) == set()
+
+
+def test_search_invalid_last_updated_is_400(api, patient):
+    add_observations(patient=patient, code=Code.HeartRate, n=1)
+
+    r = api.get("/FHIR/R5/Observation", {"_lastUpdated": "ge-not-a-date"})
+
+    assert r.status_code == 400, r.text


### PR DESCRIPTION
First slice of US Core query support: generic _id (exact) and _lastUpdated (ge/le/gt/lt + bare-date) applied at the search-queryset layer for mapped and aux resources. Remaining modifiers tracked as a follow-up. Addresses #585 (does not fully close it).