### PR TITLE
chore: use a fast password hasher in tests

### DIFF
--- a/jhe/test_settings.py
+++ b/jhe/test_settings.py
@@ -14,3 +14,7 @@ DATABASES = {
 }
 
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
+
+# Fast password hashing for tests: speeds up every test that creates a user and sidesteps a
+# flaky native pbkdf2 access-violation crash seen on Windows. Never use MD5 in production.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]

--- a/tests/backend/test_test_settings.py
+++ b/tests/backend/test_test_settings.py
@@ -1,0 +1,9 @@
+"""Guard: the test settings use a fast password hasher. This keeps the suite fast and
+sidesteps a flaky native pbkdf2 access-violation crash on Windows; if it regresses,
+user-creating tests slow down and the full suite can crash."""
+
+from django.conf import settings
+
+
+def test_tests_use_fast_password_hasher():
+    assert settings.PASSWORD_HASHERS[0] == "django.contrib.auth.hashers.MD5PasswordHasher"


### PR DESCRIPTION
Sets PASSWORD_HASHERS to MD5PasswordHasher in jhe/test_settings.py: speeds up every test that creates a user, and sidesteps a flaky native pbkdf2 access-violation crash on Windows. Adds a guard test asserting the fast hasher is configured. Test-settings only; no production behavior change.