### PR TITLE
feat(mcp): cover IEEE-namespaced seeded codes (sleep-stage-summary)

### DIFF
--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -18,10 +18,10 @@ dependencies = [
     "fastapi>=0.138.0,<1",
     "uvicorn[standard]>=0.49.0,<1",
     # First-party, additive (new OMH schemas land frequently). Floor must cover
-    # every OMH code JHE seeds — see tests/unit/test_omh_registry.py drift guard;
-    # 1.3.0 adds the spirometry schemas (forced-vital-capacity,
-    # forced-expiratory-volume-1-second). Uncapped so additive releases flow;
-    # Dependabot (.github/dependabot.yaml, uv / mcp_server) moves the lock.
+    # every code JHE seeds — see tests/unit/test_omh_registry.py drift guard;
+    # 1.4.0 adds the IEEE ieee:sleep-stage-summary:1.0 body schema. Uncapped so
+    # additive releases flow; Dependabot (.github/dependabot.yaml, uv /
+    # mcp_server) moves the lock.
     "omh-shim>=1.4.0",
     "cryptography>=49.0.0,<50",
 ]

--- a/mcp_server/src/jhe_mcp/omh_registry.py
+++ b/mcp_server/src/jhe_mcp/omh_registry.py
@@ -7,6 +7,15 @@ from omh_shim import load_schema as _shim_load
 
 _OMH_SYSTEM = "https://w3id.org/openmhealth"
 
+# Coding system per schema-id namespace prefix, matching the systems JHE seeds
+# in ``seed_codeable_concepts`` (e.g. ``ieee:sleep-stage-summary:1.0`` is seeded
+# under the IEEE 1752 system, not the OMH one). Unknown prefixes fall back to the
+# OMH system, preserving the prior behaviour for ``omh:`` and ``local:`` ids.
+_CODING_SYSTEMS = {
+    "omh": _OMH_SYSTEM,
+    "ieee": "https://w3id.org/ieee1752",
+}
+
 
 def all_schema_ids() -> frozenset[str]:
     return known_ids()
@@ -21,10 +30,15 @@ def short_name(schema_id: str) -> str:
     return parts[1] if len(parts) >= 2 else schema_id
 
 
+def _coding_system(schema_id: str) -> str:
+    prefix = schema_id.split(":", 1)[0]
+    return _CODING_SYSTEMS.get(prefix, _OMH_SYSTEM)
+
+
 def lookup_code(data_type_short_name: str) -> str | None:
     for sid in all_schema_ids():
         if short_name(sid) == data_type_short_name:
-            return f"{_OMH_SYSTEM}|{sid}"
+            return f"{_coding_system(sid)}|{sid}"
     return None
 
 

--- a/mcp_server/tests/unit/test_omh_registry.py
+++ b/mcp_server/tests/unit/test_omh_registry.py
@@ -11,22 +11,28 @@ _SEED_PY = Path(__file__).resolve().parents[3] / "core" / "management" / "comman
 
 
 def _jhe_seeded_short_names() -> set[str]:
-    """Derive JHE's authoritative supported OMH codes straight from seed.py.
+    """Derive JHE's authoritative supported schema codes straight from seed.py.
 
     Parses the ``seed_codeable_concepts`` block of JHE's seed command rather than
     hardcoding the set, so when JHE adds a CodeableConcept the new code is picked
     up automatically and the coverage assertion fails until omh-shim vendors a
     schema for it. A hardcoded list could not detect that drift (it would pass
     while silently missing the new code).
+
+    Matches both ``omh:`` and ``ieee:`` namespaced codes (JHE seeds at least one
+    ``ieee:`` body schema, e.g. ``ieee:sleep-stage-summary:1.0``). Codes from
+    other systems that are not omh-shim-served schema bodies — notably the FHIR
+    ``QuestionnaireResponse`` concept — have no ``<ns>:<name>:<ver>`` shape and
+    are intentionally excluded; omh-shim is not expected to serve them.
     """
     if not _SEED_PY.exists():
         pytest.skip(f"seed.py not found at {_SEED_PY} (drift check needs the monorepo checkout)")
     text = _SEED_PY.read_text()
     match = re.search(r"def seed_codeable_concepts\b.*?(?=\n    def |\Z)", text, re.DOTALL)
     block = match.group(0) if match else ""
-    codes = re.findall(r"omh:[a-z0-9-]+:[0-9.]+", block)
+    codes = re.findall(r"(?:omh|ieee):[a-z0-9-]+:[0-9.]+", block)
     if not codes:
-        pytest.fail("Parsed no OMH codes from seed_codeable_concepts; the parser is likely stale")
+        pytest.fail("Parsed no OMH/IEEE codes from seed_codeable_concepts; the parser is likely stale")
     return {short_name(c) for c in codes}
 
 
@@ -39,21 +45,28 @@ def test_all_schema_ids_from_shim():
 
 
 def test_covers_jhe_seeded_codes():
-    """omh-shim must serve every OMH code JHE seeds (guards version drift)."""
+    """omh-shim must serve every OMH/IEEE code JHE seeds (guards version drift)."""
     seeded = _jhe_seeded_short_names()
     missing = seeded - set(all_short_names())
-    assert not missing, f"omh-shim is missing JHE-seeded OMH code(s): {sorted(missing)}"
+    assert not missing, f"omh-shim is missing JHE-seeded code(s): {sorted(missing)}"
 
 
 def test_short_name_extraction():
     assert short_name("omh:heart-rate:2.0") == "heart-rate"
     assert short_name("omh:blood-pressure:4.0") == "blood-pressure"
+    assert short_name("ieee:sleep-stage-summary:1.0") == "sleep-stage-summary"
     assert short_name("local:heart-rate-variability:1.0") == "heart-rate-variability"
 
 
 def test_lookup_code_known():
     code = lookup_code("heart-rate")
     assert code == "https://w3id.org/openmhealth|omh:heart-rate:2.0"
+
+
+def test_lookup_code_ieee_uses_ieee_system():
+    """IEEE-namespaced codes resolve under the IEEE 1752 system, not the OMH one."""
+    code = lookup_code("sleep-stage-summary")
+    assert code == "https://w3id.org/ieee1752|ieee:sleep-stage-summary:1.0"
 
 
 def test_lookup_code_unknown():


### PR DESCRIPTION
## What

Make the MCP `omh_registry` correctly handle **IEEE-namespaced** seeded codes, and harden the drift guard so future IEEE drift is actually caught.

JHE's `seed_codeable_concepts` now seeds `ieee:sleep-stage-summary:1.0` as a CodeableConcept (the first `ieee:` body code, alongside the `omh:` codes). Two gaps existed:

1. **`lookup_code` returned the wrong coding system for IEEE codes** — it hardcoded the OMH system (`https://w3id.org/openmhealth`) for *every* id, so `lookup_code("sleep-stage-summary")` produced `…/openmhealth|ieee:sleep-stage-summary:1.0` instead of the IEEE system JHE actually seeds (`https://w3id.org/ieee1752`).
2. **The drift test was blind to IEEE codes** — its `seed.py` parser regex matched only `omh:…`, so a newly-seeded `ieee:` code would neither be covered nor flagged.

## Changes

- `omh_registry.lookup_code`: derive the coding system from the namespace prefix (`ieee` → `w3id.org/ieee1752`, `omh` → `w3id.org/openmhealth`); unknown prefixes fall back to OMH, preserving prior behaviour for `omh:`/`local:`.
- `test_omh_registry.py`: broaden the seed parser to `(?:omh|ieee):…`; FHIR-style concepts (e.g. `QuestionnaireResponse`) have no `<ns>:<name>:<ver>` shape and stay excluded. Add regression tests for `ieee` `short_name` + `ieee` `lookup_code` system.
- Bump `omh-shim>=1.4.0` (the release that vendors `ieee:sleep-stage-summary:1.0`) and move `uv.lock` 1.3.0 → 1.4.0.

## Verification

- `tests/unit/test_omh_registry.py` — **10/10 pass** against omh-shim 1.4.0 (now on PyPI).
- Depends on omh-shim **1.4.0** (jupyterhealth/omh-shim#25, released to PyPI).
- Context / tracking: jupyterhealth/omh-shim#21.

> Note: `tests/unit/test_session_isolation.py` has 2 failures locally, but they are **pre-existing on `main`** (reproduced with this branch's changes reverted) and unrelated to this change (MCP OAuth session/credential handling).
