### PR TITLE
fix(mcp): accept 404 as a valid session-isolation rejection

### DIFF
--- a/mcp_server/tests/unit/test_session_isolation.py
+++ b/mcp_server/tests/unit/test_session_isolation.py
@@ -203,8 +203,11 @@ async def test_s1_mismatched_token_does_not_forward_init_token(settings, capture
         assert captured_bearers[-1] == "BBB", f"leaked stale token: {captured_bearers}"
         assert "AAA" not in captured_bearers, f"stale init-time token AAA was forwarded: {captured_bearers}"
     else:
-        # Or the request was rejected outright.
-        assert resp.status_code in (401, 403), resp.status_code
+        # Or the request was rejected outright. The mcp streamable-http
+        # transport returns 404 for a session whose credential doesn't match
+        # the one that created it (it won't even confirm the session exists),
+        # so 404 is a valid rejection alongside 401/403.
+        assert resp.status_code in (401, 403, 404), resp.status_code
         assert "AAA" not in captured_bearers, f"stale init-time token AAA was forwarded: {captured_bearers}"
 
 
@@ -225,7 +228,9 @@ async def test_s4_attacker_token_on_victim_session_not_executed_as_victim(settin
     if resp.status_code == 200:
         assert captured_bearers[-1] == "BBB", captured_bearers
     else:
-        assert resp.status_code in (401, 403), resp.status_code
+        # 404: mcp rejects a credential-mismatched session as not-found (it
+        # won't confirm the session exists). A valid rejection, like 401/403.
+        assert resp.status_code in (401, 403, 404), resp.status_code
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The **Lint and unit tests** job has been failing on `main` (independent of any feature PR) since recent dependency bumps. Two MCP session-isolation tests fail with `AssertionError: 404 in (401, 403)`:

- `test_s1_mismatched_token_does_not_forward_init_token`
- `test_s4_attacker_token_on_victim_session_not_executed_as_victim`

`tests/unit/test_session_isolation.py` hasn't changed since the MCP server was introduced (#488), so this is a behavior change from the dependency layer (e.g. starlette 1.0.1→1.3.1 #593, the minor-patch group #614). The current pinned `mcp` streamable-http transport now returns **404** for a `tools/call` on a session whose bearer credential doesn't match the one that created it — rejecting without confirming the session exists. The server log confirms it: *"Rejecting request for session …: credential does not match the one that created the session."*

## Fix

Broaden the rejection allowlist from `(401, 403)` to `(401, 403, 404)` in both tests.

The **security property is unchanged and still strictly asserted**: the victim's token (`AAA`) is never forwarded. 404 is a safe rejection — arguably stronger, since it doesn't even reveal that the session exists to an attacker.

## Verification

- `pytest tests/unit/test_session_isolation.py` → 5/5 pass
- `pytest tests/unit` → **155 passed, 0 failed**

Unblocks the **Lint and unit tests** check for all MCP PRs (e.g. #641).
