### PR TITLE
feat(mcp): adopt FHIR search APIs (date filtering, counts, sort, patient lookup)

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -79,7 +79,7 @@ The MCP server exposes the following tools to LLM clients. Every tool runs as th
 - **Observations:** `count_patient_observations`, `count_study_observations`, `summarize_patient_observations`, `get_patient_observations`
 - **OMH schemas:** `get_omh_schema` (schemas are also browsable as resources at `omh://schema/<name>`)
 
-The observation and patient-search tools rely on JHE's FHIR search support (`date`, `_summary=count`, `_sort`, and the Patient search params introduced in #667); a JHE without it silently ignores unknown search params, so date windows and ordering would not be applied.
+The observation and patient-search tools rely on JHE's FHIR search support (`date`, `_summary=count`, `_sort`, and the Patient search params introduced in #667); a JHE without it silently ignores unknown search params, so date windows and ordering would not be applied. **Deploy order matters:** roll out the JHE backend with #667 before (never after) deploying this server — against a stale backend the ignored `_sort` silently corrupts `get_patient_date_range`, it doesn't just widen date windows.
 
 ---
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -75,9 +75,11 @@ Set the required environment variables before starting (see the [Configuration r
 The MCP server exposes the following tools to LLM clients. Every tool runs as the authenticated user and only returns data that user is authorized to see. See the [Tools section in the docs](https://jupyterhealth.github.io/software-documentation/jhe/mcp-server#tools) for full descriptions.
 
 - **Studies:** `get_study_count`, `list_studies`, `get_study_metadata`, `list_study_patients`
-- **Patients:** `get_patient_demographics`, `get_patient_date_range`
+- **Patients:** `search_patients`, `get_patient_demographics`, `get_patient_date_range`
 - **Observations:** `count_patient_observations`, `count_study_observations`, `summarize_patient_observations`, `get_patient_observations`
 - **OMH schemas:** `get_omh_schema` (schemas are also browsable as resources at `omh://schema/<name>`)
+
+The observation and patient-search tools rely on JHE's FHIR search support (`date`, `_summary=count`, `_sort`, and the Patient search params introduced in #667); a JHE without it silently ignores unknown search params, so date windows and ordering would not be applied.
 
 ---
 

--- a/mcp_server/src/jhe_mcp/audit.py
+++ b/mcp_server/src/jhe_mcp/audit.py
@@ -1,9 +1,12 @@
 """Deliberate, structured audit log for JHE data access.
 
-Records WHO (subject), WHAT (method + resource path — the path intentionally
-includes the target study/patient id for audit traceability), and RESULT
-(HTTP status). Never logs response bodies or token values, so it carries
-identifiers but no PHI.
+Records WHO (subject), WHAT (method + resource path), and RESULT (HTTP
+status). Where the target id is part of the path (reads, per-patient queries)
+it is intentionally included for audit traceability; search requests carry
+their criteria (names, birthdates) only in query params, which are NEVER
+logged — a search audit line records that a search happened, not against
+whom. Never logs response bodies or token values, so it carries identifiers
+but no PHI.
 """
 
 from __future__ import annotations

--- a/mcp_server/src/jhe_mcp/core.py
+++ b/mcp_server/src/jhe_mcp/core.py
@@ -44,8 +44,8 @@ Tools by purpose:
 Key behaviors:
 - Dates are OPTIONAL on observation tools. Pass start/end as YYYY-MM-DD (inclusive)
   to filter by the observation's effective time; omit them to include everything.
-  Date bounds are compared in UTC on the server, so a reading near midnight in a
-  non-UTC timezone can fall on the neighboring day.
+  Date bounds are compared in the server's timezone (UTC by default), so a
+  reading near midnight in another timezone can fall on the neighboring day.
 - get_patient_observations returns {total, page, page_size, returned, has_more,
   observations}. It defaults to compact "slim" records (type, time, value, unit) and
   omits the raw OMH body. Pass verbosity="full" only when you need raw bodies. Page
@@ -61,7 +61,7 @@ Efficient workflows — do NOT dump or page through records just to count or fin
 - First/last data for a patient: get_patient_date_range(patient_id) ->
   {earliest, latest, count}. Never page to the end to find min/max dates.
 - "Show me everything" for a patient: start with summarize_patient_observations
-  (per-type {count, earliest, latest}) for the overview, then page
+  ({truncated, types: {type: {count, earliest, latest}}}) for the overview, then page
   get_patient_observations (slim); fetch verbosity="full" only for specific records.
 - Need a data type's schema: get_omh_schema("blood-glucose"), etc.
 """
@@ -189,12 +189,14 @@ def build_server(
         """Find patients by name and/or birth date; returns a page of matches.
 
         String params are case-insensitive PREFIX matches ("smi" matches
-        Smith); `name` matches family or given. `birthdate` is YYYY-MM-DD with
-        an optional ge/le/gt/lt prefix (bare = exact day). At least one
+        Smith); a comma ORs values ("smith,jones"), so don't pass "Last, First"
+        as one value. `name` matches family or given. `birthdate` is YYYY-MM-DD
+        with an optional ge/le/gt/lt prefix (bare = exact day). At least one
         criterion is required. Returns {total, page, page_size, returned,
         has_more, patients}; each patient has patient_id, given_name,
-        family_name, birth_date, phone, email. Only patients the caller is
-        authorized to see are returned.
+        family_name, birth_date, phone, email. limit is capped at 1000;
+        requesting a page past the end returns an error — follow has_more.
+        Only patients the caller is authorized to see are returned.
         """
         if auth_msg := await _before():
             return auth_msg
@@ -226,7 +228,8 @@ def build_server(
         value/unit) and omits the raw OMH body; verbosity='full' includes it.
         order='newest' (default) returns most recent first; 'oldest' returns
         oldest first. Filter by OMH data type short name (e.g. 'blood-glucose')
-        and ISO dates.
+        and ISO dates. limit is capped at 1000; requesting a page past the end
+        returns an error — follow has_more instead.
         """
         if auth_msg := await _before():
             return auth_msg
@@ -285,9 +288,11 @@ def build_server(
         start: str | None = None,
         end: str | None = None,
     ) -> dict | str:
-        """Compact per-data-type digest for a patient: {type: {count, earliest, latest}}.
+        """Compact digest for a patient: {truncated, types: {type: {count, earliest, latest}}}.
 
         Use this for 'show me everything' overviews instead of dumping records.
+        truncated=true means the underlying fetch hit its bound and the counts
+        are lower bounds — narrow the date window for exact numbers.
         """
         if auth_msg := await _before():
             return auth_msg

--- a/mcp_server/src/jhe_mcp/core.py
+++ b/mcp_server/src/jhe_mcp/core.py
@@ -14,6 +14,7 @@ from jhe_mcp.auth.token_verifier import JheTokenVerifier
 from jhe_mcp.config import Settings
 from jhe_mcp.omh_registry import all_schema_ids, all_short_names, load_schema, short_name
 from jhe_mcp.tools import observation_counts, observation_views
+from jhe_mcp.tools import patients as patient_tools
 from jhe_mcp.tools import study as study_tools
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ only returns data that user is authorized to see.
 
 Tools by purpose:
 - Studies: get_study_count, list_studies, get_study_metadata, list_study_patients
-- Patients: get_patient_demographics, get_patient_date_range
+- Patients: search_patients, get_patient_demographics, get_patient_date_range
 - Observations: count_patient_observations, count_study_observations,
   summarize_patient_observations, get_patient_observations
 - OMH schemas: get_omh_schema(name); also browsable as resources at omh://schema/<name>
@@ -49,6 +50,10 @@ Key behaviors:
   with limit/page and use total/has_more to know when you've read everything.
 
 Efficient workflows — do NOT dump or page through records just to count or find dates:
+- Find a patient: search_patients(name=..., birthdate=...) — prefix match on
+  names — then use the returned patient_id with the other tools.
+- Need newest readings first? get_patient_observations already returns
+  newest-first; pass order="oldest" for chronological order.
 - Counts: use count_patient_observations / count_study_observations
   (count_study_observations(by_patient=true) returns {patient_id: count} in one call).
 - First/last data for a patient: get_patient_date_range(patient_id) ->
@@ -169,6 +174,37 @@ def build_server(
             return auth_msg
         d = await study_tools.get_patient_demographics(patient_id=patient_id, base_url=base_url)
         return d.model_dump() if d else None
+
+    @mcp.tool()
+    async def search_patients(
+        name: str | None = None,
+        family: str | None = None,
+        given: str | None = None,
+        birthdate: str | None = None,
+        limit: int = 50,
+        page: int = 1,
+    ) -> dict | str:
+        """Find patients by name and/or birth date; returns a page of matches.
+
+        String params are case-insensitive PREFIX matches ("smi" matches
+        Smith); `name` matches family or given. `birthdate` is YYYY-MM-DD with
+        an optional ge/le/gt/lt prefix (bare = exact day). At least one
+        criterion is required. Returns {total, page, page_size, returned,
+        has_more, patients}; each patient has patient_id, given_name,
+        family_name, birth_date, phone, email. Only patients the caller is
+        authorized to see are returned.
+        """
+        if auth_msg := await _before():
+            return auth_msg
+        return await patient_tools.search_patients(
+            name=name,
+            family=family,
+            given=given,
+            birthdate=birthdate,
+            limit=limit,
+            page=page,
+            base_url=base_url,
+        )
 
     @mcp.tool()
     async def get_patient_observations(

--- a/mcp_server/src/jhe_mcp/core.py
+++ b/mcp_server/src/jhe_mcp/core.py
@@ -44,6 +44,8 @@ Tools by purpose:
 Key behaviors:
 - Dates are OPTIONAL on observation tools. Pass start/end as YYYY-MM-DD (inclusive)
   to filter by the observation's effective time; omit them to include everything.
+  Date bounds are compared in UTC on the server, so a reading near midnight in a
+  non-UTC timezone can fall on the neighboring day.
 - get_patient_observations returns {total, page, page_size, returned, has_more,
   observations}. It defaults to compact "slim" records (type, time, value, unit) and
   omits the raw OMH body. Pass verbosity="full" only when you need raw bodies. Page

--- a/mcp_server/src/jhe_mcp/core.py
+++ b/mcp_server/src/jhe_mcp/core.py
@@ -177,6 +177,7 @@ def build_server(
         start: str | None = None,
         end: str | None = None,
         verbosity: str = "slim",
+        order: str = "newest",
         limit: int = 50,
         page: int = 1,
     ) -> dict | str:
@@ -185,7 +186,9 @@ def build_server(
         Returns {total, page, page_size, returned, has_more, observations}.
         verbosity='slim' (default) returns compact records (type, time,
         value/unit) and omits the raw OMH body; verbosity='full' includes it.
-        Filter by OMH data type short name (e.g. 'blood-glucose') and ISO dates.
+        order='newest' (default) returns most recent first; 'oldest' returns
+        oldest first. Filter by OMH data type short name (e.g. 'blood-glucose')
+        and ISO dates.
         """
         if auth_msg := await _before():
             return auth_msg
@@ -195,6 +198,7 @@ def build_server(
             start=start,
             end=end,
             verbosity=verbosity,
+            order=order,
             limit=limit,
             page=page,
             base_url=base_url,

--- a/mcp_server/src/jhe_mcp/fhir/client.py
+++ b/mcp_server/src/jhe_mcp/fhir/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import httpx
@@ -8,6 +9,8 @@ from mcp.server.auth.middleware.auth_context import get_access_token
 
 from jhe_mcp.audit import log_access
 from jhe_mcp.auth.context import current_auth, current_auth_required
+
+logger = logging.getLogger(__name__)
 
 
 def assert_request_ctx_importable() -> None:
@@ -85,7 +88,10 @@ class JheClientError(Exception):
     MAX_BODY = 500
 
     def __init__(self, status: int, body: str) -> None:
-        body = body if len(body) <= self.MAX_BODY else body[: self.MAX_BODY] + "…[truncated]"
+        if len(body) > self.MAX_BODY:
+            # Keep the full body reachable for operators before it is cut.
+            logger.debug("Full JHE error body (%d chars, status %s): %s", len(body), status, body)
+            body = body[: self.MAX_BODY] + "…[truncated]"
         super().__init__(f"JHE {status}: {body}")
         self.status = status
         self.body = body

--- a/mcp_server/src/jhe_mcp/fhir/client.py
+++ b/mcp_server/src/jhe_mcp/fhir/client.py
@@ -79,7 +79,13 @@ def _per_request_subject() -> str | None:
 
 
 class JheClientError(Exception):
+    # Cap how much of an upstream body is carried in the error: JHE's own error
+    # payloads are short, so anything longer is a proxy/HTML page or a raw
+    # traceback that shouldn't be forwarded wholesale to the MCP client.
+    MAX_BODY = 500
+
     def __init__(self, status: int, body: str) -> None:
+        body = body if len(body) <= self.MAX_BODY else body[: self.MAX_BODY] + "…[truncated]"
         super().__init__(f"JHE {status}: {body}")
         self.status = status
         self.body = body

--- a/mcp_server/src/jhe_mcp/fhir/models.py
+++ b/mcp_server/src/jhe_mcp/fhir/models.py
@@ -170,3 +170,33 @@ class SlimObservation(BaseModel):
             value=value,
             unit=unit,
         )
+
+
+class PatientSearchResult(BaseModel):
+    patient_id: str
+    given_name: str | None = None
+    family_name: str | None = None
+    birth_date: str | None = None
+    phone: str | None = None
+    email: str | None = None
+
+    @classmethod
+    def from_fhir_entry(cls, entry: dict[str, Any]) -> PatientSearchResult:
+        r = entry.get("resource") or entry
+        name = (r.get("name") or [{}])[0]
+        given = (name.get("given") or [None])[0]
+
+        def _telecom(system: str) -> str | None:
+            for item in r.get("telecom") or []:
+                if item.get("system") == system and item.get("value"):
+                    return item["value"]
+            return None
+
+        return cls(
+            patient_id=str(r["id"]),
+            given_name=given,
+            family_name=name.get("family"),
+            birth_date=r.get("birthDate"),
+            phone=_telecom("phone"),
+            email=_telecom("email"),
+        )

--- a/mcp_server/src/jhe_mcp/fhir/models.py
+++ b/mcp_server/src/jhe_mcp/fhir/models.py
@@ -99,6 +99,12 @@ class Observation(BaseModel):
             if effective_at is None:
                 interval = tf.get("time_interval") or {}
                 effective_at = interval.get("start_date_time") or interval.get("end_date_time")
+        if effective_at is None:
+            # OMH shapes this parser doesn't compute (e.g. date + part_of_day)
+            # are still projected onto the FHIR effective[x] elements by the
+            # server — fall back to those so the record stays placeable in time
+            # (and isn't skipped as a date-range boundary).
+            effective_at = r.get("effectiveDateTime") or (r.get("effectivePeriod") or {}).get("start")
         return cls(
             observation_id=str(r["id"]),
             patient_id=patient_id,
@@ -182,7 +188,13 @@ class PatientSearchResult(BaseModel):
 
     @classmethod
     def from_fhir_entry(cls, entry: dict[str, Any]) -> PatientSearchResult:
+        from jhe_mcp.fhir.client import JheClientError
+
         r = entry.get("resource") or entry
+        if not isinstance(r, dict) or "id" not in r:
+            # Labeled like bundle_total's guard: a malformed upstream entry must
+            # not surface as an anonymous KeyError.
+            raise JheClientError(0, f"Expected a Patient entry with an id, got: {str(entry)[:200]}")
         name = (r.get("name") or [{}])[0]
         given = (name.get("given") or [None])[0]
 

--- a/mcp_server/src/jhe_mcp/fhir/observation_query.py
+++ b/mcp_server/src/jhe_mcp/fhir/observation_query.py
@@ -3,33 +3,26 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date
 from typing import Any
 
-from jhe_mcp.fhir.client import JheClient, JheClientError
+from jhe_mcp.fhir.client import JheClient
 from jhe_mcp.fhir.models import Observation
+from jhe_mcp.fhir.paging import MAX_PAGE_SIZE, bundle_total
 from jhe_mcp.omh_registry import all_short_names, lookup_code
 
 logger = logging.getLogger(__name__)
 
-MAX_PAGE_SIZE = 1000
 # Upper bound on pages walked by iter_all_observations, so a backend that
 # reports an enormous (or wrong) `total` can't make us page indefinitely / OOM.
 # MAX_PAGE_SIZE * MAX_PAGES is the most records a single call will pull.
 MAX_PAGES = 50
 
-
-def bundle_total(bundle: Any) -> int:
-    """Return a FHIR search Bundle's ``total``, rejecting non-Bundle responses.
-
-    JHE returns 200 with a search Bundle for FHIR queries. If the body is
-    something else (an error envelope, a non-dict), reading ``total`` would
-    otherwise default to 0 and silently report "no results" for what is
-    actually a failure — so raise instead.
-    """
-    if not isinstance(bundle, dict) or "total" not in bundle:
-        raise JheClientError(0, f"Expected a FHIR search Bundle with 'total', got: {str(bundle)[:200]}")
-    return int(bundle["total"])
+# Strictly dashed YYYY-MM-DD: date.fromisoformat alone also accepts compact
+# (20260401) and week-date (2026-W14-2) forms that the server's parser rejects
+# or reads as a different day — those must fail HERE with the clear message.
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 def _require_iso_date(value: str | None, label: str) -> None:
@@ -41,6 +34,8 @@ def _require_iso_date(value: str | None, label: str) -> None:
     if value is None:
         return
     try:
+        if not _ISO_DATE_RE.fullmatch(value):
+            raise ValueError
         date.fromisoformat(value)
     except ValueError:
         raise ValueError(f"{label} must be an ISO date (YYYY-MM-DD); got {value!r}") from None
@@ -107,28 +102,30 @@ async def fetch_observation_page(
     return total, entries, has_more
 
 
-async def iter_all_observations(client: JheClient, params: dict[str, Any]) -> list[dict]:
+async def iter_all_observations(client: JheClient, params: dict[str, Any]) -> tuple[list[dict], bool]:
     """Page through every matching entry (raw bundle entries), bounded by ``MAX_PAGES``.
 
-    Any date window is already inside ``params`` and applied server-side, so
-    this walks only the (possibly windowed) match set.
+    Returns ``(entries, truncated)``: ``truncated`` is True when the bound was
+    hit and the result is incomplete — callers must surface that rather than
+    presenting a partial set as complete. Any date window is already inside
+    ``params`` and applied server-side.
     """
     out: list[dict] = []
     for page in range(1, MAX_PAGES + 1):
         total, entries, has_more = await fetch_observation_page(client, params, page=page, page_size=MAX_PAGE_SIZE)
         out.extend(entries)
         if not has_more or not entries:
-            return out
+            return out, False
     logger.warning(
         "iter_all_observations hit MAX_PAGES=%d (%d records) for params=%s; result truncated",
         MAX_PAGES,
         len(out),
         params,
     )
-    return out
+    return out, True
 
 
-async def collect_observations(client: JheClient, params: dict[str, Any]) -> list[Observation]:
-    """Fetch all matching observations as parsed models (server applies any filters)."""
-    entries = await iter_all_observations(client, params)
-    return [Observation.from_fhir_entry(e) for e in entries]
+async def collect_observations(client: JheClient, params: dict[str, Any]) -> tuple[list[Observation], bool]:
+    """Fetch all matching observations as parsed models; ``(observations, truncated)``."""
+    entries, truncated = await iter_all_observations(client, params)
+    return [Observation.from_fhir_entry(e) for e in entries], truncated

--- a/mcp_server/src/jhe_mcp/fhir/observation_query.py
+++ b/mcp_server/src/jhe_mcp/fhir/observation_query.py
@@ -19,7 +19,7 @@ MAX_PAGE_SIZE = 1000
 MAX_PAGES = 50
 
 
-def _bundle_total(bundle: Any) -> int:
+def bundle_total(bundle: Any) -> int:
     """Return a FHIR search Bundle's ``total``, rejecting non-Bundle responses.
 
     JHE returns 200 with a search Bundle for FHIR queries. If the body is
@@ -85,7 +85,7 @@ def build_observation_params(
 async def count_observations(client: JheClient, params: dict[str, Any]) -> int:
     """Exact count via ``_summary=count`` — the server returns only the total."""
     bundle = await client.fhir_get("Observation", params={**params, "_summary": "count"})
-    return _bundle_total(bundle)
+    return bundle_total(bundle)
 
 
 async def fetch_observation_page(
@@ -101,7 +101,7 @@ async def fetch_observation_page(
     if sort is not None:
         page_params["_sort"] = sort
     bundle = await client.fhir_get("Observation", params=page_params)
-    total = _bundle_total(bundle)
+    total = bundle_total(bundle)
     entries = bundle.get("entry", []) or []
     has_more = page * page_size < total
     return total, entries, has_more

--- a/mcp_server/src/jhe_mcp/fhir/observation_query.py
+++ b/mcp_server/src/jhe_mcp/fhir/observation_query.py
@@ -1,3 +1,5 @@
+"""Shared FHIR Observation query building, counting, and paging helpers."""
+
 from __future__ import annotations
 
 import logging
@@ -20,9 +22,9 @@ MAX_PAGES = 50
 def _bundle_total(bundle: Any) -> int:
     """Return a FHIR search Bundle's ``total``, rejecting non-Bundle responses.
 
-    JHE returns 200 with a search Bundle for Observation queries. If the body is
+    JHE returns 200 with a search Bundle for FHIR queries. If the body is
     something else (an error envelope, a non-dict), reading ``total`` would
-    otherwise default to 0 and silently report "no observations" for what is
+    otherwise default to 0 and silently report "no results" for what is
     actually a failure — so raise instead.
     """
     if not isinstance(bundle, dict) or "total" not in bundle:
@@ -30,18 +32,36 @@ def _bundle_total(bundle: Any) -> int:
     return int(bundle["total"])
 
 
+def _require_iso_date(value: str | None, label: str) -> None:
+    """Validate a date-window bound is ISO ``YYYY-MM-DD``, or raise a clear error.
+
+    Called at the param-building choke point so a malformed tool argument fails
+    with an actionable message before any request is sent.
+    """
+    if value is None:
+        return
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        raise ValueError(f"{label} must be an ISO date (YYYY-MM-DD); got {value!r}") from None
+
+
 def build_observation_params(
     *,
     patient_id: str | None = None,
     study_id: str | None = None,
     data_type: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
 ) -> dict[str, Any]:
     """Build FHIR Observation query params shared by all observation tools.
 
-    Date filtering is intentionally NOT included here: the JHE FHIR Observation
-    endpoint does not parse a ``date`` parameter, so any date window is applied
-    client-side (see ``in_date_range`` / ``collect_observations``).
+    ``start``/``end`` (inclusive, ``YYYY-MM-DD``) become repeated FHIR ``date``
+    params (``ge{start}``/``le{end}``): day-precision values are compared at day
+    precision by JHE, so both bounds are inclusive, matching the tools' contract.
     """
+    _require_iso_date(start, "start")
+    _require_iso_date(end, "end")
     params: dict[str, Any] = {}
     if study_id is not None:
         params["patient._has:_group:member:_id"] = study_id
@@ -52,50 +72,19 @@ def build_observation_params(
         if code is None:
             raise ValueError(f"Unknown data_type {data_type!r}. Known: {all_short_names()}")
         params["code"] = code
+    date_filters = []
+    if start:
+        date_filters.append(f"ge{start}")
+    if end:
+        date_filters.append(f"le{end}")
+    if date_filters:
+        params["date"] = date_filters  # list value -> repeated query param (AND)
     return params
 
 
-def _require_iso_date(value: str | None, label: str) -> None:
-    """Validate a date-window bound is ISO ``YYYY-MM-DD``, or raise a clear error.
-
-    Called once at the filtering choke point so a malformed tool argument fails
-    with an actionable message rather than a raw ValueError surfacing mid-filter.
-    """
-    if value is None:
-        return
-    try:
-        date.fromisoformat(value)
-    except ValueError:
-        raise ValueError(f"{label} must be an ISO date (YYYY-MM-DD); got {value!r}") from None
-
-
-def in_date_range(effective_at: str | None, start: str | None, end: str | None) -> bool:
-    """Inclusive date-window check on an observation's effective timestamp.
-
-    Parses the date portion of an ISO-8601 ``effective_at`` and compares it to
-    ``start``/``end`` (``YYYY-MM-DD``). Observations whose effective timestamp is
-    absent (``None``) or not parseable as an ISO date are treated as out of range
-    when a window is given: they cannot be confidently placed in time, so the
-    previous ``effective_at[:10]`` string slice — which would mis-filter a
-    non-ISO timestamp silently — is replaced with an explicit parse + skip.
-    """
-    if effective_at is None:
-        return False
-    try:
-        day = date.fromisoformat(effective_at[:10])
-    except ValueError:
-        logger.warning("Skipping observation with non-ISO effective_at during date filtering")
-        return False
-    if start and day < date.fromisoformat(start):
-        return False
-    if end and day > date.fromisoformat(end):
-        return False
-    return True
-
-
 async def count_observations(client: JheClient, params: dict[str, Any]) -> int:
-    """Exact count via the bundle `total`, requesting a single record."""
-    bundle = await client.fhir_get("Observation", params={**params, "_count": 1})
+    """Exact count via ``_summary=count`` — the server returns only the total."""
+    bundle = await client.fhir_get("Observation", params={**params, "_summary": "count"})
     return _bundle_total(bundle)
 
 
@@ -105,9 +94,13 @@ async def fetch_observation_page(
     *,
     page: int,
     page_size: int,
+    sort: str | None = None,
 ) -> tuple[int, list[dict], bool]:
-    """Return (total, entries, has_more) for one FHIR page."""
-    bundle = await client.fhir_get("Observation", params={**params, "_count": page_size, "_page": page})
+    """Return (total, entries, has_more) for one FHIR page, optionally ``_sort``-ed."""
+    page_params = {**params, "_count": page_size, "_page": page}
+    if sort is not None:
+        page_params["_sort"] = sort
+    bundle = await client.fhir_get("Observation", params=page_params)
     total = _bundle_total(bundle)
     entries = bundle.get("entry", []) or []
     has_more = page * page_size < total
@@ -115,11 +108,10 @@ async def fetch_observation_page(
 
 
 async def iter_all_observations(client: JheClient, params: dict[str, Any]) -> list[dict]:
-    """Page through every matching entry server-side (raw bundle entries).
+    """Page through every matching entry (raw bundle entries), bounded by ``MAX_PAGES``.
 
-    Bounded by ``MAX_PAGES``; if the result set is larger, we stop and log a
-    warning rather than paging indefinitely (the date-filtered / summarize paths
-    fetch everything because JHE ignores the ``date`` param).
+    Any date window is already inside ``params`` and applied server-side, so
+    this walks only the (possibly windowed) match set.
     """
     out: list[dict] = []
     for page in range(1, MAX_PAGES + 1):
@@ -136,36 +128,7 @@ async def iter_all_observations(client: JheClient, params: dict[str, Any]) -> li
     return out
 
 
-async def collect_observations(
-    client: JheClient,
-    params: dict[str, Any],
-    *,
-    start: str | None = None,
-    end: str | None = None,
-) -> list[Observation]:
-    """Fetch all matching observations, applying a client-side date window.
-
-    The backend ignores date params, so when ``start``/``end`` are supplied we
-    fetch the full (patient/study/code-scoped) set and filter in process on each
-    record's ``effective_at``.
-    """
-    _require_iso_date(start, "start")
-    _require_iso_date(end, "end")
+async def collect_observations(client: JheClient, params: dict[str, Any]) -> list[Observation]:
+    """Fetch all matching observations as parsed models (server applies any filters)."""
     entries = await iter_all_observations(client, params)
-    observations = [Observation.from_fhir_entry(e) for e in entries]
-    if start or end:
-        observations = [o for o in observations if in_date_range(o.effective_at, start, end)]
-    return observations
-
-
-async def count_with_optional_date(
-    client: JheClient,
-    params: dict[str, Any],
-    start: str | None,
-    end: str | None,
-) -> int:
-    """Count observations, using the cheap bundle `total` when no date window is
-    given, and a client-side filtered full fetch when one is."""
-    if not (start or end):
-        return await count_observations(client, params)
-    return len(await collect_observations(client, params, start=start, end=end))
+    return [Observation.from_fhir_entry(e) for e in entries]

--- a/mcp_server/src/jhe_mcp/fhir/paging.py
+++ b/mcp_server/src/jhe_mcp/fhir/paging.py
@@ -1,0 +1,42 @@
+"""Shared FHIR search paging: the server's page cap, bundle validation, page envelopes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jhe_mcp.fhir.client import JheClientError
+
+# Mirrors the server's FHIRBundlePagination.max_page_size (core/fhir/pagination.py).
+# If that cap ever changes, this clamp and the has_more arithmetic drift with it —
+# keep the two in sync.
+MAX_PAGE_SIZE = 1000
+
+
+def bundle_total(bundle: Any) -> int:
+    """Return a FHIR search Bundle's ``total``, rejecting non-Bundle responses.
+
+    JHE returns 200 with a search Bundle for FHIR queries. If the body is
+    something else (an error envelope, a non-dict), reading ``total`` would
+    otherwise default to 0 and silently report "no results" for what is
+    actually a failure — so raise instead.
+    """
+    if not isinstance(bundle, dict) or "total" not in bundle:
+        raise JheClientError(0, f"Expected a FHIR search Bundle with 'total', got: {str(bundle)[:200]}")
+    return int(bundle["total"])
+
+
+def clamp_paging(limit: int, page: int) -> tuple[int, int]:
+    """Clamp tool paging args to (page_size 1..MAX_PAGE_SIZE, page >= 1)."""
+    return max(1, min(int(limit), MAX_PAGE_SIZE)), max(1, int(page))
+
+
+def page_envelope(*, total: int, page: int, page_size: int, items_key: str, items: list) -> dict[str, Any]:
+    """The paged response shape shared by every list-returning tool."""
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "returned": len(items),
+        "has_more": page * page_size < total,
+        items_key: items,
+    }

--- a/mcp_server/src/jhe_mcp/tools/observation_counts.py
+++ b/mcp_server/src/jhe_mcp/tools/observation_counts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 
 from jhe_mcp.fhir.client import JheClient
-from jhe_mcp.fhir.observation_query import build_observation_params, count_with_optional_date
+from jhe_mcp.fhir.observation_query import build_observation_params, count_observations
 from jhe_mcp.tools.study import list_study_patients
 
 # Bound on concurrent per-patient count requests for the by_patient path, so a
@@ -20,9 +20,9 @@ async def count_patient_observations(
     base_url: str,
 ) -> int:
     """Exact number of observations for a patient (optionally filtered)."""
-    params = build_observation_params(patient_id=patient_id, data_type=data_type)
+    params = build_observation_params(patient_id=patient_id, data_type=data_type, start=start, end=end)
     async with JheClient(base_url) as client:
-        return await count_with_optional_date(client, params, start, end)
+        return await count_observations(client, params)
 
 
 async def count_study_observations(
@@ -36,9 +36,9 @@ async def count_study_observations(
 ) -> int | dict[str, int]:
     """Observation count for a whole study, or per-patient when by_patient=True."""
     if not by_patient:
-        params = build_observation_params(study_id=study_id, data_type=data_type)
+        params = build_observation_params(study_id=study_id, data_type=data_type, start=start, end=end)
         async with JheClient(base_url) as client:
-            return await count_with_optional_date(client, params, start, end)
+            return await count_observations(client, params)
 
     patients = await list_study_patients(study_id=study_id, base_url=base_url)
     sem = asyncio.Semaphore(_MAX_CONCURRENT_PATIENT_COUNTS)
@@ -46,8 +46,8 @@ async def count_study_observations(
 
         async def _count(patient_id: str) -> int:
             async with sem:
-                params = build_observation_params(patient_id=patient_id, data_type=data_type)
-                return await count_with_optional_date(client, params, start, end)
+                params = build_observation_params(patient_id=patient_id, data_type=data_type, start=start, end=end)
+                return await count_observations(client, params)
 
         results = await asyncio.gather(*(_count(p.patient_id) for p in patients))
     return {p.patient_id: c for p, c in zip(patients, results, strict=True)}

--- a/mcp_server/src/jhe_mcp/tools/observation_views.py
+++ b/mcp_server/src/jhe_mcp/tools/observation_views.py
@@ -7,8 +7,11 @@ from jhe_mcp.fhir.models import Observation, SlimObservation
 from jhe_mcp.fhir.observation_query import (
     build_observation_params,
     collect_observations,
+    count_observations,
     fetch_observation_page,
 )
+
+_ORDER_TO_SORT = {"newest": "-date", "oldest": "date"}
 
 
 async def summarize_patient_observations(
@@ -18,10 +21,15 @@ async def summarize_patient_observations(
     end: str | None = None,
     base_url: str,
 ) -> dict[str, dict[str, Any]]:
-    """Per-data-type digest for a patient: {type: {count, earliest, latest}}."""
-    params = build_observation_params(patient_id=patient_id)
+    """Per-data-type digest for a patient: {type: {count, earliest, latest}}.
+
+    Aggregation is client-side (the server has no group-by, and the summary must
+    include data types outside the OMH registry), but any date window bounds the
+    fetch server-side.
+    """
+    params = build_observation_params(patient_id=patient_id, start=start, end=end)
     async with JheClient(base_url) as client:
-        observations = await collect_observations(client, params, start=start, end=end)
+        observations = await collect_observations(client, params)
     summary: dict[str, dict[str, Any]] = {}
     for obs in observations:
         key = obs.code_display or obs.code or "unknown"
@@ -43,20 +51,21 @@ async def get_patient_date_range(
 ) -> dict[str, Any]:
     """Earliest/latest observation timestamp and total count for a patient.
 
-    Fetches the patient's observations server-side and reduces to a compact
-    ``{earliest, latest, count}`` so the caller gets exact first/last dates in a
-    single call instead of paging to the end. ``earliest``/``latest`` are
-    ISO-8601 strings (``None`` if no record has a parseable timestamp).
+    Three cheap server-side queries: ``_summary=count`` for the total, then a
+    single record sorted ascending / descending by effective date. No paging.
+    ``earliest``/``latest`` are ISO-8601 strings (``None`` when there are no
+    records or the boundary record has no parseable effective time).
     """
     params = build_observation_params(patient_id=patient_id)
     async with JheClient(base_url) as client:
-        observations = await collect_observations(client, params)
-    dated = [o.effective_at for o in observations if o.effective_at]
-    return {
-        "earliest": min(dated) if dated else None,
-        "latest": max(dated) if dated else None,
-        "count": len(observations),
-    }
+        count = await count_observations(client, params)
+        if count == 0:
+            return {"earliest": None, "latest": None, "count": 0}
+        _, first_entries, _ = await fetch_observation_page(client, params, page=1, page_size=1, sort="date")
+        _, last_entries, _ = await fetch_observation_page(client, params, page=1, page_size=1, sort="-date")
+    earliest = Observation.from_fhir_entry(first_entries[0]).effective_at if first_entries else None
+    latest = Observation.from_fhir_entry(last_entries[0]).effective_at if last_entries else None
+    return {"earliest": earliest, "latest": latest, "count": count}
 
 
 async def get_patient_observations(
@@ -66,6 +75,7 @@ async def get_patient_observations(
     start: str | None = None,
     end: str | None = None,
     verbosity: str = "slim",
+    order: str = "newest",
     limit: int = 50,
     page: int = 1,
     base_url: str,
@@ -73,27 +83,21 @@ async def get_patient_observations(
     """One page of a patient's observations with total/has_more awareness.
 
     verbosity="slim" (default) omits the raw OMH body; "full" includes it.
-    With a start/end window the backend cannot filter by date, so the full set
-    is fetched and filtered client-side, then paginated in process.
+    Date windows and ordering are applied server-side (FHIR ``date`` + ``_sort``).
     """
     if verbosity not in ("slim", "full"):
         raise ValueError(f"verbosity must be 'slim' or 'full', got {verbosity!r}")
-    params = build_observation_params(patient_id=patient_id, data_type=data_type)
+    sort = _ORDER_TO_SORT.get(order)
+    if sort is None:
+        raise ValueError(f"order must be 'newest' or 'oldest', got {order!r}")
+    params = build_observation_params(patient_id=patient_id, data_type=data_type, start=start, end=end)
     page_size = max(1, min(int(limit), 1000))
     page = max(1, int(page))
-
-    if start or end:
-        async with JheClient(base_url) as client:
-            filtered = await collect_observations(client, params, start=start, end=end)
-        total = len(filtered)
-        offset = (page - 1) * page_size
-        observations = filtered[offset : offset + page_size]
-        has_more = offset + page_size < total
-    else:
-        async with JheClient(base_url) as client:
-            total, entries, has_more = await fetch_observation_page(client, params, page=page, page_size=page_size)
-        observations = [Observation.from_fhir_entry(e) for e in entries]
-
+    async with JheClient(base_url) as client:
+        total, entries, has_more = await fetch_observation_page(
+            client, params, page=page, page_size=page_size, sort=sort
+        )
+    observations = [Observation.from_fhir_entry(e) for e in entries]
     if verbosity == "slim":
         payload = [SlimObservation.from_observation(o).model_dump() for o in observations]
     else:

--- a/mcp_server/src/jhe_mcp/tools/observation_views.py
+++ b/mcp_server/src/jhe_mcp/tools/observation_views.py
@@ -9,14 +9,18 @@ from jhe_mcp.fhir.observation_query import (
     collect_observations,
     fetch_observation_page,
 )
+from jhe_mcp.fhir.paging import clamp_paging, page_envelope
 
 _ORDER_TO_SORT = {"newest": "-date", "oldest": "date"}
 
-# Entries fetched per date-range boundary. The server's descending date sort
-# places records with no effective time first (SQL NULLS FIRST), so a single
-# record could be an undated one; probing a few lets us skip past them to the
-# first record that actually carries a timestamp.
+# Entries fetched per date-range boundary, letting the pick skip records whose
+# effective time is unparseable client-side.
 _BOUNDARY_PROBE = 5
+# The descending boundary probe adds this filter so records with NO effective
+# time (which the server's DESC sort places first — SQL NULLS FIRST) are
+# excluded server-side; without it, a cluster of undated records would make
+# `latest` come back None despite dated data existing.
+_ANY_DATE_FILTER = ["ge0001-01-01"]
 
 
 def _first_effective_at(entries: list[dict]) -> str | None:
@@ -33,20 +37,21 @@ async def summarize_patient_observations(
     start: str | None = None,
     end: str | None = None,
     base_url: str,
-) -> dict[str, dict[str, Any]]:
-    """Per-data-type digest for a patient: {type: {count, earliest, latest}}.
+) -> dict[str, Any]:
+    """Per-data-type digest for a patient: {truncated, types: {type: {count, earliest, latest}}}.
 
     Aggregation is client-side (the server has no group-by, and the summary must
     include data types outside the OMH registry), but any date window bounds the
-    fetch server-side.
+    fetch server-side. ``truncated`` is True when the bounded fetch could not
+    cover every record, meaning the per-type counts are lower bounds.
     """
     params = build_observation_params(patient_id=patient_id, start=start, end=end)
     async with JheClient(base_url) as client:
-        observations = await collect_observations(client, params)
-    summary: dict[str, dict[str, Any]] = {}
+        observations, truncated = await collect_observations(client, params)
+    types: dict[str, dict[str, Any]] = {}
     for obs in observations:
         key = obs.code_display or obs.code or "unknown"
-        bucket = summary.setdefault(key, {"count": 0, "earliest": None, "latest": None})
+        bucket = types.setdefault(key, {"count": 0, "earliest": None, "latest": None})
         bucket["count"] += 1
         at = obs.effective_at
         if at:
@@ -54,7 +59,7 @@ async def summarize_patient_observations(
                 bucket["earliest"] = at
             if bucket["latest"] is None or at > bucket["latest"]:
                 bucket["latest"] = at
-    return summary
+    return {"truncated": truncated, "types": types}
 
 
 async def get_patient_date_range(
@@ -65,10 +70,10 @@ async def get_patient_date_range(
     """Earliest/latest observation timestamp and total count for a patient.
 
     Two cheap server-side queries: a few records sorted ascending by effective
-    date (whose bundle also carries the total), then a few sorted descending.
-    Undated records are skipped when picking each boundary, so
-    ``earliest``/``latest`` are ISO-8601 strings from the oldest/newest records
-    that actually carry a timestamp (``None`` when no probed record does).
+    date (whose bundle also carries the total), then the newest dated record
+    (the descending probe filters out undated records server-side). ``count``
+    includes undated records; ``earliest``/``latest`` are ISO-8601 strings from
+    dated records only (``None`` when there are none).
     """
     params = build_observation_params(patient_id=patient_id)
     async with JheClient(base_url) as client:
@@ -78,7 +83,11 @@ async def get_patient_date_range(
         if total == 0:
             return {"earliest": None, "latest": None, "count": 0}
         _, last_entries, _ = await fetch_observation_page(
-            client, params, page=1, page_size=_BOUNDARY_PROBE, sort="-date"
+            client,
+            {**params, "date": _ANY_DATE_FILTER},
+            page=1,
+            page_size=_BOUNDARY_PROBE,
+            sort="-date",
         )
     return {
         "earliest": _first_effective_at(first_entries),
@@ -103,6 +112,7 @@ async def get_patient_observations(
 
     verbosity="slim" (default) omits the raw OMH body; "full" includes it.
     Date windows and ordering are applied server-side (FHIR ``date`` + ``_sort``).
+    ``limit`` is clamped to 1..MAX_PAGE_SIZE (the server's page cap).
     """
     if verbosity not in ("slim", "full"):
         raise ValueError(f"verbosity must be 'slim' or 'full', got {verbosity!r}")
@@ -110,22 +120,12 @@ async def get_patient_observations(
     if sort is None:
         raise ValueError(f"order must be 'newest' or 'oldest', got {order!r}")
     params = build_observation_params(patient_id=patient_id, data_type=data_type, start=start, end=end)
-    page_size = max(1, min(int(limit), 1000))
-    page = max(1, int(page))
+    page_size, page = clamp_paging(limit, page)
     async with JheClient(base_url) as client:
-        total, entries, has_more = await fetch_observation_page(
-            client, params, page=page, page_size=page_size, sort=sort
-        )
+        total, entries, _ = await fetch_observation_page(client, params, page=page, page_size=page_size, sort=sort)
     observations = [Observation.from_fhir_entry(e) for e in entries]
     if verbosity == "slim":
         payload = [SlimObservation.from_observation(o).model_dump() for o in observations]
     else:
         payload = [o.model_dump() for o in observations]
-    return {
-        "total": total,
-        "page": page,
-        "page_size": page_size,
-        "returned": len(payload),
-        "has_more": has_more,
-        "observations": payload,
-    }
+    return page_envelope(total=total, page=page, page_size=page_size, items_key="observations", items=payload)

--- a/mcp_server/src/jhe_mcp/tools/observation_views.py
+++ b/mcp_server/src/jhe_mcp/tools/observation_views.py
@@ -7,11 +7,24 @@ from jhe_mcp.fhir.models import Observation, SlimObservation
 from jhe_mcp.fhir.observation_query import (
     build_observation_params,
     collect_observations,
-    count_observations,
     fetch_observation_page,
 )
 
 _ORDER_TO_SORT = {"newest": "-date", "oldest": "date"}
+
+# Entries fetched per date-range boundary. The server's descending date sort
+# places records with no effective time first (SQL NULLS FIRST), so a single
+# record could be an undated one; probing a few lets us skip past them to the
+# first record that actually carries a timestamp.
+_BOUNDARY_PROBE = 5
+
+
+def _first_effective_at(entries: list[dict]) -> str | None:
+    for entry in entries:
+        at = Observation.from_fhir_entry(entry).effective_at
+        if at:
+            return at
+    return None
 
 
 async def summarize_patient_observations(
@@ -51,21 +64,27 @@ async def get_patient_date_range(
 ) -> dict[str, Any]:
     """Earliest/latest observation timestamp and total count for a patient.
 
-    Three cheap server-side queries: ``_summary=count`` for the total, then a
-    single record sorted ascending / descending by effective date. No paging.
-    ``earliest``/``latest`` are ISO-8601 strings (``None`` when there are no
-    records or the boundary record has no parseable effective time).
+    Two cheap server-side queries: a few records sorted ascending by effective
+    date (whose bundle also carries the total), then a few sorted descending.
+    Undated records are skipped when picking each boundary, so
+    ``earliest``/``latest`` are ISO-8601 strings from the oldest/newest records
+    that actually carry a timestamp (``None`` when no probed record does).
     """
     params = build_observation_params(patient_id=patient_id)
     async with JheClient(base_url) as client:
-        count = await count_observations(client, params)
-        if count == 0:
+        total, first_entries, _ = await fetch_observation_page(
+            client, params, page=1, page_size=_BOUNDARY_PROBE, sort="date"
+        )
+        if total == 0:
             return {"earliest": None, "latest": None, "count": 0}
-        _, first_entries, _ = await fetch_observation_page(client, params, page=1, page_size=1, sort="date")
-        _, last_entries, _ = await fetch_observation_page(client, params, page=1, page_size=1, sort="-date")
-    earliest = Observation.from_fhir_entry(first_entries[0]).effective_at if first_entries else None
-    latest = Observation.from_fhir_entry(last_entries[0]).effective_at if last_entries else None
-    return {"earliest": earliest, "latest": latest, "count": count}
+        _, last_entries, _ = await fetch_observation_page(
+            client, params, page=1, page_size=_BOUNDARY_PROBE, sort="-date"
+        )
+    return {
+        "earliest": _first_effective_at(first_entries),
+        "latest": _first_effective_at(last_entries),
+        "count": total,
+    }
 
 
 async def get_patient_observations(

--- a/mcp_server/src/jhe_mcp/tools/patients.py
+++ b/mcp_server/src/jhe_mcp/tools/patients.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from jhe_mcp.fhir.client import JheClient
 from jhe_mcp.fhir.models import PatientSearchResult
-from jhe_mcp.fhir.observation_query import _bundle_total
+from jhe_mcp.fhir.observation_query import MAX_PAGE_SIZE, bundle_total
 
 _DATE_PREFIXES = ("ge", "le", "gt", "lt")
 
@@ -25,6 +25,13 @@ def build_patient_params(
     prefix (bare value = exact day). Raises ``ValueError`` when no criterion is
     given or the birthdate is malformed, so the tool fails before any request.
     """
+    # Strip before the truthiness checks so whitespace-only values can't slip
+    # past the at-least-one-criterion guard (the server skips blank filters,
+    # which would turn "  " into an unfiltered list of every visible patient).
+    name = name.strip() if name else None
+    family = family.strip() if family else None
+    given = given.strip() if given else None
+    birthdate = birthdate.strip() if birthdate else None
     params: dict[str, Any] = {}
     if name:
         params["name"] = name
@@ -56,13 +63,16 @@ async def search_patients(
     page: int = 1,
     base_url: str,
 ) -> dict[str, Any]:
-    """One page of matching patients: {total, page, page_size, returned, has_more, patients}."""
+    """One page of matching patients: {total, page, page_size, returned, has_more, patients}.
+
+    ``limit`` is clamped to 1..MAX_PAGE_SIZE (the server's page-size cap).
+    """
     params = build_patient_params(name=name, family=family, given=given, birthdate=birthdate)
-    page_size = max(1, min(int(limit), 1000))
+    page_size = max(1, min(int(limit), MAX_PAGE_SIZE))
     page = max(1, int(page))
     async with JheClient(base_url) as client:
         bundle = await client.fhir_get("Patient", params={**params, "_count": page_size, "_page": page})
-    total = _bundle_total(bundle)
+    total = bundle_total(bundle)
     entries = bundle.get("entry", []) or []
     patients = [PatientSearchResult.from_fhir_entry(e).model_dump() for e in entries]
     return {

--- a/mcp_server/src/jhe_mcp/tools/patients.py
+++ b/mcp_server/src/jhe_mcp/tools/patients.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date
 from typing import Any
 
 from jhe_mcp.fhir.client import JheClient
 from jhe_mcp.fhir.models import PatientSearchResult
-from jhe_mcp.fhir.observation_query import MAX_PAGE_SIZE, bundle_total
+from jhe_mcp.fhir.paging import bundle_total, clamp_paging, page_envelope
 
 _DATE_PREFIXES = ("ge", "le", "gt", "lt")
+# Strictly dashed YYYY-MM-DD (see observation_query._require_iso_date for why
+# date.fromisoformat alone is too lenient).
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 def build_patient_params(
@@ -28,6 +32,9 @@ def build_patient_params(
     # Strip before the truthiness checks so whitespace-only values can't slip
     # past the at-least-one-criterion guard (the server skips blank filters,
     # which would turn "  " into an unfiltered list of every visible patient).
+    # NOTE this guard prevents *accidental* unfiltered listings only — a broad
+    # criterion (birthdate="le9999-12-31") legitimately matches everyone the
+    # caller may see. The security boundary is JHE's server-side authorization.
     name = name.strip() if name else None
     family = family.strip() if family else None
     given = given.strip() if given else None
@@ -42,6 +49,8 @@ def build_patient_params(
     if birthdate:
         value = birthdate[2:] if birthdate[:2] in _DATE_PREFIXES else birthdate
         try:
+            if not _ISO_DATE_RE.fullmatch(value):
+                raise ValueError
             date.fromisoformat(value)
         except ValueError:
             raise ValueError(
@@ -68,18 +77,10 @@ async def search_patients(
     ``limit`` is clamped to 1..MAX_PAGE_SIZE (the server's page-size cap).
     """
     params = build_patient_params(name=name, family=family, given=given, birthdate=birthdate)
-    page_size = max(1, min(int(limit), MAX_PAGE_SIZE))
-    page = max(1, int(page))
+    page_size, page = clamp_paging(limit, page)
     async with JheClient(base_url) as client:
         bundle = await client.fhir_get("Patient", params={**params, "_count": page_size, "_page": page})
     total = bundle_total(bundle)
     entries = bundle.get("entry", []) or []
     patients = [PatientSearchResult.from_fhir_entry(e).model_dump() for e in entries]
-    return {
-        "total": total,
-        "page": page,
-        "page_size": page_size,
-        "returned": len(patients),
-        "has_more": page * page_size < total,
-        "patients": patients,
-    }
+    return page_envelope(total=total, page=page, page_size=page_size, items_key="patients", items=patients)

--- a/mcp_server/src/jhe_mcp/tools/patients.py
+++ b/mcp_server/src/jhe_mcp/tools/patients.py
@@ -1,0 +1,75 @@
+"""Patient lookup via the JHE FHIR Patient search API (JHE PR #667)."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from jhe_mcp.fhir.client import JheClient
+from jhe_mcp.fhir.models import PatientSearchResult
+from jhe_mcp.fhir.observation_query import _bundle_total
+
+_DATE_PREFIXES = ("ge", "le", "gt", "lt")
+
+
+def build_patient_params(
+    *,
+    name: str | None = None,
+    family: str | None = None,
+    given: str | None = None,
+    birthdate: str | None = None,
+) -> dict[str, Any]:
+    """FHIR Patient search params. String params are case-insensitive prefix matches.
+
+    ``birthdate`` is ``YYYY-MM-DD`` with an optional ``ge``/``le``/``gt``/``lt``
+    prefix (bare value = exact day). Raises ``ValueError`` when no criterion is
+    given or the birthdate is malformed, so the tool fails before any request.
+    """
+    params: dict[str, Any] = {}
+    if name:
+        params["name"] = name
+    if family:
+        params["family"] = family
+    if given:
+        params["given"] = given
+    if birthdate:
+        value = birthdate[2:] if birthdate[:2] in _DATE_PREFIXES else birthdate
+        try:
+            date.fromisoformat(value)
+        except ValueError:
+            raise ValueError(
+                f"birthdate must be YYYY-MM-DD with an optional ge/le/gt/lt prefix; got {birthdate!r}"
+            ) from None
+        params["birthdate"] = birthdate
+    if not params:
+        raise ValueError("Provide at least one of: name, family, given, birthdate.")
+    return params
+
+
+async def search_patients(
+    *,
+    name: str | None = None,
+    family: str | None = None,
+    given: str | None = None,
+    birthdate: str | None = None,
+    limit: int = 50,
+    page: int = 1,
+    base_url: str,
+) -> dict[str, Any]:
+    """One page of matching patients: {total, page, page_size, returned, has_more, patients}."""
+    params = build_patient_params(name=name, family=family, given=given, birthdate=birthdate)
+    page_size = max(1, min(int(limit), 1000))
+    page = max(1, int(page))
+    async with JheClient(base_url) as client:
+        bundle = await client.fhir_get("Patient", params={**params, "_count": page_size, "_page": page})
+    total = _bundle_total(bundle)
+    entries = bundle.get("entry", []) or []
+    patients = [PatientSearchResult.from_fhir_entry(e).model_dump() for e in entries]
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "returned": len(patients),
+        "has_more": page * page_size < total,
+        "patients": patients,
+    }

--- a/mcp_server/tests/unit/test_core_registration.py
+++ b/mcp_server/tests/unit/test_core_registration.py
@@ -12,6 +12,7 @@ async def test_observation_tools_registered(monkeypatch):
     mcp = build_server(Settings.from_env())
     # Server instructions are sent to every client on initialize.
     assert mcp.instructions and "get_patient_date_range" in mcp.instructions
+    assert "search_patients" in mcp.instructions
     names = {tool.name for tool in await mcp.list_tools()}
     assert {
         "get_patient_observations",
@@ -19,4 +20,5 @@ async def test_observation_tools_registered(monkeypatch):
         "count_study_observations",
         "summarize_patient_observations",
         "get_patient_date_range",
+        "search_patients",
     } <= names

--- a/mcp_server/tests/unit/test_fhir_client.py
+++ b/mcp_server/tests/unit/test_fhir_client.py
@@ -116,3 +116,14 @@ async def test_audit_log_emitted_on_error(auth, caplog):
     assert len(records) == 1
     assert records[0].status == 403
     assert records[0].path == "/api/v1/studies/1"
+
+
+def test_jhe_client_error_truncates_long_bodies():
+    # Proxy pages / tracebacks must not be forwarded wholesale to MCP clients;
+    # both the message and the .body attribute carry the capped form.
+    err = JheClientError(500, "x" * 600)
+    assert err.body.endswith("…[truncated]")
+    assert len(err.body) == JheClientError.MAX_BODY + len("…[truncated]")
+    assert str(err).startswith("JHE 500: xxx")
+    short = JheClientError(400, "short body")
+    assert short.body == "short body"

--- a/mcp_server/tests/unit/test_fhir_models.py
+++ b/mcp_server/tests/unit/test_fhir_models.py
@@ -176,3 +176,17 @@ def test_observation_from_fhir_entry_non_json_attachment_data():
     o = Observation.from_fhir_entry(entry)
     assert o.observation_id == "obs-badjson"
     assert o.omh_body is None
+
+
+def test_observation_effective_falls_back_to_fhir_elements():
+    # OMH time-frame shapes the parser doesn't compute (e.g. date + part_of_day)
+    # are still projected onto FHIR effective[x] by the server — use those so
+    # the record stays placeable in time.
+    from jhe_mcp.fhir.models import Observation
+
+    instant = Observation.from_fhir_entry({"resource": {"id": "o1", "effectiveDateTime": "2026-07-18T09:30:00+00:00"}})
+    assert instant.effective_at == "2026-07-18T09:30:00+00:00"
+    period = Observation.from_fhir_entry(
+        {"resource": {"id": "o2", "effectivePeriod": {"start": "2026-07-18T06:00:00+00:00"}}}
+    )
+    assert period.effective_at == "2026-07-18T06:00:00+00:00"

--- a/mcp_server/tests/unit/test_observation_counts.py
+++ b/mcp_server/tests/unit/test_observation_counts.py
@@ -1,5 +1,3 @@
-import base64
-import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -9,19 +7,6 @@ from jhe_mcp.tools.observation_counts import (
     count_patient_observations,
     count_study_observations,
 )
-
-
-def _entry_at(obs_id: str, when: str) -> dict:
-    payload = {"body": {"heart_rate": {"value": 70, "unit": "beats/min"}, "effective_time_frame": {"date_time": when}}}
-    return {
-        "resource": {
-            "resourceType": "Observation",
-            "id": obs_id,
-            "code": {"coding": [{"system": "https://w3id.org/openmhealth", "code": "omh:heart-rate:2.0"}]},
-            "subject": {"reference": "Patient/40006"},
-            "valueAttachment": {"data": base64.b64encode(json.dumps(payload).encode()).decode()},
-        }
-    }
 
 
 @pytest.fixture
@@ -47,7 +32,7 @@ async def test_count_patient_observations(auth, fake_client):
     n = await count_patient_observations(patient_id="40006", base_url="http://jhe")
     assert n == 57
     sent = fake_client.fhir_get.await_args.kwargs["params"]
-    assert sent["patient"] == "40006" and sent["_count"] == 1
+    assert sent["patient"] == "40006" and sent["_summary"] == "count"
 
 
 @pytest.mark.asyncio
@@ -57,6 +42,7 @@ async def test_count_study_observations_total(auth, fake_client):
     assert n == 980
     sent = fake_client.fhir_get.await_args.kwargs["params"]
     assert sent["patient._has:_group:member:_id"] == "30006"
+    assert sent["_summary"] == "count"
 
 
 @pytest.mark.asyncio
@@ -77,19 +63,12 @@ async def test_count_study_observations_by_patient(auth, fake_client, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_count_patient_observations_date_filter_is_client_side(auth, fake_client):
-    # Backend ignores `date`, so a date window triggers a full fetch + in-process filter.
-    fake_client.fhir_get.return_value = {
-        "total": 3,
-        "entry": [
-            _entry_at("o1", "2026-04-05T00:00:00Z"),
-            _entry_at("o2", "2026-04-20T00:00:00Z"),
-            _entry_at("o3", "2026-05-10T00:00:00Z"),
-        ],
-    }
+async def test_count_patient_observations_date_filter_is_server_side(auth, fake_client):
+    fake_client.fhir_get.return_value = {"total": 2}
     n = await count_patient_observations(
         patient_id="40006", start="2026-04-01", end="2026-04-30", base_url="http://jhe"
     )
-    assert n == 2  # o1, o2 in window; o3 (May) excluded
+    assert n == 2  # server-filtered total, no record fetch
     sent = fake_client.fhir_get.await_args.kwargs["params"]
-    assert sent["_count"] == 1000  # full-fetch page, not the cheap _count=1 path
+    assert sent["_summary"] == "count"
+    assert sent["date"] == ["ge2026-04-01", "le2026-04-30"]

--- a/mcp_server/tests/unit/test_observation_query.py
+++ b/mcp_server/tests/unit/test_observation_query.py
@@ -34,6 +34,12 @@ def test_build_params_rejects_non_iso_window():
         build_observation_params(patient_id="7", start="last week")
     with pytest.raises(ValueError, match="end must be an ISO date"):
         build_observation_params(patient_id="7", end="04/30/2026")
+    # fromisoformat alone would accept these; the server would reject or
+    # misread them, so they must fail client-side with the clear message.
+    with pytest.raises(ValueError, match="start must be an ISO date"):
+        build_observation_params(patient_id="7", start="20260401")
+    with pytest.raises(ValueError, match="end must be an ISO date"):
+        build_observation_params(patient_id="7", end="2026-W14-2")
 
 
 def test_build_params_study_scope():
@@ -95,8 +101,9 @@ async def test_iter_all_follows_pages():
         {"total": 1500, "entry": [{"resource": {"id": str(i)}} for i in range(1000)]},
         {"total": 1500, "entry": [{"resource": {"id": str(i)}} for i in range(500)]},
     ]
-    entries = await iter_all_observations(client, {"patient": "7"})
+    entries, truncated = await iter_all_observations(client, {"patient": "7"})
     assert len(entries) == 1500
+    assert truncated is False
     assert client.fhir_get.await_count == 2
 
 
@@ -106,8 +113,9 @@ async def test_collect_observations_parses_entries_no_client_side_filtering():
     # inside params (built by build_observation_params), applied by the server.
     client = AsyncMock()
     client.fhir_get.return_value = {"total": 1, "entry": [{"resource": {"id": "o1"}}]}
-    observations = await collect_observations(client, {"patient": "7", "date": ["ge2026-04-01"]})
+    observations, truncated = await collect_observations(client, {"patient": "7", "date": ["ge2026-04-01"]})
     assert [o.observation_id for o in observations] == ["o1"]
+    assert truncated is False
     sent = client.fhir_get.await_args.kwargs["params"]
     assert sent["date"] == ["ge2026-04-01"]
 
@@ -142,6 +150,7 @@ async def test_iter_all_observations_caps_at_max_pages():
     client = AsyncMock()
     huge = oq.MAX_PAGE_SIZE * (oq.MAX_PAGES + 5)
     client.fhir_get.return_value = {"total": huge, "entry": [{} for _ in range(oq.MAX_PAGE_SIZE)]}
-    out = await iter_all_observations(client, {"patient": "7"})
+    out, truncated = await iter_all_observations(client, {"patient": "7"})
     assert client.fhir_get.await_count == oq.MAX_PAGES
     assert len(out) == oq.MAX_PAGE_SIZE * oq.MAX_PAGES
+    assert truncated is True  # callers surface this instead of presenting a partial set as complete

--- a/mcp_server/tests/unit/test_observation_query.py
+++ b/mcp_server/tests/unit/test_observation_query.py
@@ -5,9 +5,9 @@ from jhe_mcp.fhir import observation_query as oq
 from jhe_mcp.fhir.client import JheClientError
 from jhe_mcp.fhir.observation_query import (
     build_observation_params,
+    collect_observations,
     count_observations,
     fetch_observation_page,
-    in_date_range,
     iter_all_observations,
 )
 
@@ -16,34 +16,24 @@ def test_build_params_patient_and_code():
     params = build_observation_params(patient_id="7", data_type="blood-glucose")
     assert params["patient"] == "7"
     assert "omh:blood-glucose:4.0" in params["code"]
-    # date is filtered client-side, never sent to the backend
-    assert "date" not in params
+    assert "date" not in params  # no window given -> no date param
 
 
-def test_in_date_range_inclusive_and_undated():
-    assert in_date_range("2026-04-15T08:00:00Z", "2026-04-01", "2026-04-30") is True
-    assert in_date_range("2026-04-01T00:00:00Z", "2026-04-01", "2026-04-30") is True  # start inclusive
-    assert in_date_range("2026-04-30T23:59:00Z", "2026-04-01", "2026-04-30") is True  # end inclusive
-    assert in_date_range("2026-05-01T00:00:00Z", "2026-04-01", "2026-04-30") is False
-    assert in_date_range("2026-03-31T00:00:00Z", "2026-04-01", None) is False
-    assert in_date_range(None, "2026-04-01", "2026-04-30") is False  # undated excluded
-    assert in_date_range("2026-04-15T08:00:00Z", None, None) is True  # no window
+def test_build_params_emits_server_side_date_window():
+    params = build_observation_params(patient_id="7", start="2026-04-01", end="2026-04-30")
+    assert params["date"] == ["ge2026-04-01", "le2026-04-30"]
 
 
-def test_in_date_range_non_iso_excluded():
-    # A non-ISO effective_at can't be placed in time, so it is excluded rather
-    # than mis-filtered by a naive string slice/compare. Mirrors the undated
-    # (effective_at=None) contract: unplaceable timestamps are out of range.
-    assert in_date_range("04/15/2026", "2026-04-01", "2026-04-30") is False
-    assert in_date_range("not-a-date", "2026-04-01", None) is False
-    assert in_date_range("04/15/2026", None, None) is False
+def test_build_params_open_ended_windows():
+    assert build_observation_params(patient_id="7", start="2026-04-01")["date"] == ["ge2026-04-01"]
+    assert build_observation_params(patient_id="7", end="2026-04-30")["date"] == ["le2026-04-30"]
 
 
-def test_require_iso_date_rejects_bad_window():
-    oq._require_iso_date("2026-04-01", "start")  # valid: no raise
-    oq._require_iso_date(None, "start")  # absent: no raise
+def test_build_params_rejects_non_iso_window():
     with pytest.raises(ValueError, match="start must be an ISO date"):
-        oq._require_iso_date("last week", "start")
+        build_observation_params(patient_id="7", start="last week")
+    with pytest.raises(ValueError, match="end must be an ISO date"):
+        build_observation_params(patient_id="7", end="04/30/2026")
 
 
 def test_build_params_study_scope():
@@ -57,14 +47,15 @@ def test_build_params_unknown_data_type_raises():
 
 
 @pytest.mark.asyncio
-async def test_count_observations_reads_total_not_entries():
+async def test_count_observations_uses_summary_count():
     client = AsyncMock()
-    client.fhir_get.return_value = {"resourceType": "Bundle", "total": 4242, "entry": [{}]}
-    n = await count_observations(client, {"patient": "7"})
+    client.fhir_get.return_value = {"resourceType": "Bundle", "total": 4242}
+    n = await count_observations(client, {"patient": "7", "date": ["ge2026-04-01"]})
     assert n == 4242
     sent = client.fhir_get.await_args.kwargs["params"]
-    assert sent["_count"] == 1
+    assert sent["_summary"] == "count"
     assert sent["patient"] == "7"
+    assert sent["date"] == ["ge2026-04-01"]  # filters ride along with the count
 
 
 @pytest.mark.asyncio
@@ -77,6 +68,16 @@ async def test_fetch_page_returns_total_entries_has_more():
     assert has_more is True
     sent = client.fhir_get.await_args.kwargs["params"]
     assert sent["_count"] == 50 and sent["_page"] == 1
+    assert "_sort" not in sent  # sort only sent when asked for
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_passes_sort_through():
+    client = AsyncMock()
+    client.fhir_get.return_value = {"total": 1, "entry": [{"resource": {"id": "a"}}]}
+    await fetch_observation_page(client, {"patient": "7"}, page=1, page_size=1, sort="-date")
+    sent = client.fhir_get.await_args.kwargs["params"]
+    assert sent["_sort"] == "-date"
 
 
 @pytest.mark.asyncio
@@ -99,7 +100,16 @@ async def test_iter_all_follows_pages():
     assert client.fhir_get.await_count == 2
 
 
-# --- #1: a non-Bundle 200 must raise, not be silently reported as 0/empty ---
+@pytest.mark.asyncio
+async def test_collect_observations_parses_entries_no_client_side_filtering():
+    # collect_observations no longer takes start/end: any date window is already
+    # inside params (built by build_observation_params), applied by the server.
+    client = AsyncMock()
+    client.fhir_get.return_value = {"total": 1, "entry": [{"resource": {"id": "o1"}}]}
+    observations = await collect_observations(client, {"patient": "7", "date": ["ge2026-04-01"]})
+    assert [o.observation_id for o in observations] == ["o1"]
+    sent = client.fhir_get.await_args.kwargs["params"]
+    assert sent["date"] == ["ge2026-04-01"]
 
 
 @pytest.mark.asyncio
@@ -118,9 +128,6 @@ async def test_fetch_page_rejects_non_bundle_body():
         await fetch_observation_page(client, {"patient": "7"}, page=1, page_size=50)
 
 
-# --- has_more boundary (previously untested) ---
-
-
 @pytest.mark.asyncio
 async def test_has_more_false_when_page_exactly_consumes_total():
     client = AsyncMock()
@@ -128,9 +135,6 @@ async def test_has_more_false_when_page_exactly_consumes_total():
     total, _, has_more = await fetch_observation_page(client, {"patient": "7"}, page=2, page_size=50)
     assert total == 100
     assert has_more is False
-
-
-# --- #4: iter_all_observations is bounded so a misbehaving server can't OOM us ---
 
 
 @pytest.mark.asyncio

--- a/mcp_server/tests/unit/test_observation_views.py
+++ b/mcp_server/tests/unit/test_observation_views.py
@@ -62,6 +62,7 @@ async def test_get_patient_observations_slim_envelope(auth, fake_client):
     assert "omh_body" not in rec
     sent = fake_client.fhir_get.await_args.kwargs["params"]
     assert sent["_count"] == 50 and sent["_page"] == 1
+    assert sent["_sort"] == "-date"  # default order is newest-first
 
 
 @pytest.mark.asyncio
@@ -93,83 +94,80 @@ async def test_summarize_groups_by_type_with_date_range(auth, fake_client):
 
 
 @pytest.mark.asyncio
-async def test_get_patient_observations_date_filter_client_side(auth, fake_client):
-    # Backend ignores `date`; tool fetches all, filters by effective_at, paginates in process.
+async def test_get_patient_observations_date_filter_server_side(auth, fake_client):
+    # The date window is sent to the backend; the tool pages the windowed set directly.
     fake_client.fhir_get.return_value = {
-        "total": 3,
+        "total": 2,
         "entry": [
             _entry("o1", "omh:blood-glucose:4.0", "Blood glucose", "2026-04-05T00:00:00Z", 90),
             _entry("o2", "omh:blood-glucose:4.0", "Blood glucose", "2026-04-20T00:00:00Z", 95),
-            _entry("o3", "omh:blood-glucose:4.0", "Blood glucose", "2026-05-10T00:00:00Z", 99),
         ],
     }
     result = await get_patient_observations(
         patient_id="40006", start="2026-04-01", end="2026-04-30", limit=50, page=1, base_url="http://jhe"
     )
-    assert result["total"] == 2  # filtered client-side, not the backend's 3
+    assert result["total"] == 2
     assert result["returned"] == 2
-    assert [o["observation_id"] for o in result["observations"]] == ["o1", "o2"]
     sent = fake_client.fhir_get.await_args.kwargs["params"]
-    assert sent["_count"] == 1000  # full-fetch path, not the page-size path
+    assert sent["date"] == ["ge2026-04-01", "le2026-04-30"]
+    assert sent["_count"] == 50  # normal paging, not a full fetch
 
 
 @pytest.mark.asyncio
-async def test_get_patient_observations_date_filter_paginates_past_page_1(auth, fake_client):
-    # In-process pagination of the date-filtered set must be correct beyond page 1.
+async def test_get_patient_observations_order_oldest(auth, fake_client):
     fake_client.fhir_get.return_value = {
-        "total": 3,
+        "total": 1,
         "entry": [
             _entry("o1", "omh:blood-glucose:4.0", "Blood glucose", "2026-04-05T00:00:00Z", 90),
-            _entry("o2", "omh:blood-glucose:4.0", "Blood glucose", "2026-04-10T00:00:00Z", 95),
-            _entry("o3", "omh:blood-glucose:4.0", "Blood glucose", "2026-04-20T00:00:00Z", 99),
         ],
     }
-    result = await get_patient_observations(
-        patient_id="40006", start="2026-04-01", end="2026-04-30", limit=2, page=2, base_url="http://jhe"
-    )
-    assert result["total"] == 3
-    assert result["page"] == 2
-    assert result["returned"] == 1
-    assert result["has_more"] is False
-    assert [o["observation_id"] for o in result["observations"]] == ["o3"]
+    await get_patient_observations(patient_id="40006", order="oldest", base_url="http://jhe")
+    sent = fake_client.fhir_get.await_args.kwargs["params"]
+    assert sent["_sort"] == "date"
 
 
 @pytest.mark.asyncio
-async def test_summarize_respects_date_window(auth, fake_client):
+async def test_get_patient_observations_rejects_bad_order(auth, fake_client):
+    with pytest.raises(ValueError, match="order must be"):
+        await get_patient_observations(patient_id="40006", order="sideways", base_url="http://jhe")
+
+
+@pytest.mark.asyncio
+async def test_summarize_passes_date_window_to_server(auth, fake_client):
     fake_client.fhir_get.return_value = {
-        "total": 3,
+        "total": 2,
         "entry": [
             _entry("o1", "omh:blood-glucose:4.0", "Blood glucose", "2026-04-05T00:00:00Z", 90),
-            _entry("o2", "omh:blood-glucose:4.0", "Blood glucose", "2026-05-10T00:00:00Z", 95),
             _entry("o3", "omh:heart-rate:2.0", "Heart rate", "2026-04-12T00:00:00Z", 70),
         ],
     }
     summary = await summarize_patient_observations(
         patient_id="40006", start="2026-04-01", end="2026-04-30", base_url="http://jhe"
     )
-    assert summary["Blood glucose"]["count"] == 1  # only the April record
-    assert summary["Blood glucose"]["latest"] == "2026-04-05T00:00:00Z"
+    assert summary["Blood glucose"]["count"] == 1
     assert summary["Heart rate"]["count"] == 1
+    sent = fake_client.fhir_get.await_args.kwargs["params"]
+    assert sent["date"] == ["ge2026-04-01", "le2026-04-30"]
 
 
 @pytest.mark.asyncio
-async def test_get_patient_date_range(auth, fake_client):
-    fake_client.fhir_get.return_value = {
-        "total": 3,
-        "entry": [
-            _entry("o1", "omh:blood-glucose:4.0", "Blood glucose", "2024-03-12T22:00:00Z", 90),
-            _entry("o2", "omh:blood-glucose:4.0", "Blood glucose", "2023-01-05T08:00:00Z", 95),
-            _entry("o3", "omh:heart-rate:2.0", "Heart rate", "2024-03-15T23:16:00Z", 70),
-        ],
-    }
+async def test_get_patient_date_range_uses_sort_not_full_fetch(auth, fake_client):
+    fake_client.fhir_get.side_effect = [
+        {"total": 3},  # _summary=count
+        {"total": 3, "entry": [_entry("o2", "omh:blood-glucose:4.0", "Blood glucose", "2023-01-05T08:00:00Z", 95)]},
+        {"total": 3, "entry": [_entry("o3", "omh:heart-rate:2.0", "Heart rate", "2024-03-15T23:16:00Z", 70)]},
+    ]
     result = await get_patient_date_range(patient_id="40006", base_url="http://jhe")
-    assert result["earliest"] == "2023-01-05T08:00:00Z"
-    assert result["latest"] == "2024-03-15T23:16:00Z"
-    assert result["count"] == 3
+    assert result == {"earliest": "2023-01-05T08:00:00Z", "latest": "2024-03-15T23:16:00Z", "count": 3}
+    calls = [c.kwargs["params"] for c in fake_client.fhir_get.await_args_list]
+    assert calls[0]["_summary"] == "count"
+    assert calls[1]["_sort"] == "date" and calls[1]["_count"] == 1
+    assert calls[2]["_sort"] == "-date" and calls[2]["_count"] == 1
 
 
 @pytest.mark.asyncio
 async def test_get_patient_date_range_empty(auth, fake_client):
-    fake_client.fhir_get.return_value = {"total": 0, "entry": []}
+    fake_client.fhir_get.return_value = {"total": 0}
     result = await get_patient_date_range(patient_id="40099", base_url="http://jhe")
     assert result == {"earliest": None, "latest": None, "count": 0}
+    assert fake_client.fhir_get.await_count == 1  # zero count short-circuits the sort calls

--- a/mcp_server/tests/unit/test_observation_views.py
+++ b/mcp_server/tests/unit/test_observation_views.py
@@ -150,19 +150,61 @@ async def test_summarize_passes_date_window_to_server(auth, fake_client):
     assert sent["date"] == ["ge2026-04-01", "le2026-04-30"]
 
 
+def _undated_entry(obs_id: str) -> dict:
+    # An OMH body with no effective_time_frame: effective_at parses to None.
+    payload = {"body": {"blood_glucose": {"unit": "mg/dL", "value": 90}}}
+    return {
+        "resource": {
+            "resourceType": "Observation",
+            "id": obs_id,
+            "code": {"coding": [{"system": "https://w3id.org/openmhealth", "code": "omh:blood-glucose:4.0"}]},
+            "subject": {"reference": "Patient/40006"},
+            "valueAttachment": {"data": base64.b64encode(json.dumps(payload).encode()).decode()},
+        }
+    }
+
+
+def _sorted_responses(total: int, asc_entries: list[dict], desc_entries: list[dict]):
+    # Route the mocked fhir_get by the emitted _sort so the test doesn't couple
+    # to the order the tool issues its requests in.
+    def _get(path, params=None, **kwargs):
+        assert params.get("_summary") is None  # count comes from the sorted fetch, not a third call
+        if params.get("_sort") == "date":
+            return {"total": total, "entry": asc_entries}
+        if params.get("_sort") == "-date":
+            return {"total": total, "entry": desc_entries}
+        raise AssertionError(f"unexpected params: {params}")
+
+    return _get
+
+
 @pytest.mark.asyncio
-async def test_get_patient_date_range_uses_sort_not_full_fetch(auth, fake_client):
-    fake_client.fhir_get.side_effect = [
-        {"total": 3},  # _summary=count
-        {"total": 3, "entry": [_entry("o2", "omh:blood-glucose:4.0", "Blood glucose", "2023-01-05T08:00:00Z", 95)]},
-        {"total": 3, "entry": [_entry("o3", "omh:heart-rate:2.0", "Heart rate", "2024-03-15T23:16:00Z", 70)]},
-    ]
+async def test_get_patient_date_range_uses_sorted_probes(auth, fake_client):
+    fake_client.fhir_get.side_effect = _sorted_responses(
+        3,
+        asc_entries=[_entry("o2", "omh:blood-glucose:4.0", "Blood glucose", "2023-01-05T08:00:00Z", 95)],
+        desc_entries=[_entry("o3", "omh:heart-rate:2.0", "Heart rate", "2024-03-15T23:16:00Z", 70)],
+    )
     result = await get_patient_date_range(patient_id="40006", base_url="http://jhe")
     assert result == {"earliest": "2023-01-05T08:00:00Z", "latest": "2024-03-15T23:16:00Z", "count": 3}
-    calls = [c.kwargs["params"] for c in fake_client.fhir_get.await_args_list]
-    assert calls[0]["_summary"] == "count"
-    assert calls[1]["_sort"] == "date" and calls[1]["_count"] == 1
-    assert calls[2]["_sort"] == "-date" and calls[2]["_count"] == 1
+    assert fake_client.fhir_get.await_count == 2  # ascending probe (carries total) + descending probe
+
+
+@pytest.mark.asyncio
+async def test_get_patient_date_range_skips_undated_boundary(auth, fake_client):
+    # The server's descending date sort places undated records first (NULLS
+    # FIRST); the probe must skip them to the newest record with a timestamp.
+    fake_client.fhir_get.side_effect = _sorted_responses(
+        3,
+        asc_entries=[_entry("o1", "omh:blood-glucose:4.0", "Blood glucose", "2023-01-05T08:00:00Z", 90)],
+        desc_entries=[
+            _undated_entry("o9"),
+            _entry("o3", "omh:blood-glucose:4.0", "Blood glucose", "2024-03-15T23:16:00Z", 99),
+        ],
+    )
+    result = await get_patient_date_range(patient_id="40006", base_url="http://jhe")
+    assert result["latest"] == "2024-03-15T23:16:00Z"
+    assert result["earliest"] == "2023-01-05T08:00:00Z"
 
 
 @pytest.mark.asyncio
@@ -170,4 +212,15 @@ async def test_get_patient_date_range_empty(auth, fake_client):
     fake_client.fhir_get.return_value = {"total": 0}
     result = await get_patient_date_range(patient_id="40099", base_url="http://jhe")
     assert result == {"earliest": None, "latest": None, "count": 0}
-    assert fake_client.fhir_get.await_count == 1  # zero count short-circuits the sort calls
+    assert fake_client.fhir_get.await_count == 1  # zero total short-circuits the descending probe
+
+
+@pytest.mark.asyncio
+async def test_get_patient_observations_order_and_window_combined(auth, fake_client):
+    fake_client.fhir_get.return_value = {"total": 0}
+    await get_patient_observations(
+        patient_id="40006", start="2026-04-01", end="2026-04-30", order="oldest", base_url="http://jhe"
+    )
+    sent = fake_client.fhir_get.await_args.kwargs["params"]
+    assert sent["date"] == ["ge2026-04-01", "le2026-04-30"]
+    assert sent["_sort"] == "date"

--- a/mcp_server/tests/unit/test_observation_views.py
+++ b/mcp_server/tests/unit/test_observation_views.py
@@ -87,10 +87,12 @@ async def test_summarize_groups_by_type_with_date_range(auth, fake_client):
         ],
     }
     summary = await summarize_patient_observations(patient_id="40006", base_url="http://jhe")
-    assert summary["Blood glucose"]["count"] == 2
-    assert summary["Blood glucose"]["earliest"] == "2026-04-10T08:00:00Z"
-    assert summary["Blood glucose"]["latest"] == "2026-04-15T08:00:00Z"
-    assert summary["Heart rate"]["count"] == 1
+    assert summary["truncated"] is False
+    types = summary["types"]
+    assert types["Blood glucose"]["count"] == 2
+    assert types["Blood glucose"]["earliest"] == "2026-04-10T08:00:00Z"
+    assert types["Blood glucose"]["latest"] == "2026-04-15T08:00:00Z"
+    assert types["Heart rate"]["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -144,10 +146,22 @@ async def test_summarize_passes_date_window_to_server(auth, fake_client):
     summary = await summarize_patient_observations(
         patient_id="40006", start="2026-04-01", end="2026-04-30", base_url="http://jhe"
     )
-    assert summary["Blood glucose"]["count"] == 1
-    assert summary["Heart rate"]["count"] == 1
+    assert summary["types"]["Blood glucose"]["count"] == 1
+    assert summary["types"]["Heart rate"]["count"] == 1
     sent = fake_client.fhir_get.await_args.kwargs["params"]
     assert sent["date"] == ["ge2026-04-01", "le2026-04-30"]
+
+
+@pytest.mark.asyncio
+async def test_summarize_surfaces_truncation(auth, fake_client, monkeypatch):
+    # A bounded fetch that could not cover everything must not present its
+    # partial counts as complete.
+    async def fake_collect(client, params):
+        return [], True
+
+    monkeypatch.setattr("jhe_mcp.tools.observation_views.collect_observations", fake_collect)
+    summary = await summarize_patient_observations(patient_id="40006", base_url="http://jhe")
+    assert summary == {"truncated": True, "types": {}}
 
 
 def _undated_entry(obs_id: str) -> dict:
@@ -170,8 +184,11 @@ def _sorted_responses(total: int, asc_entries: list[dict], desc_entries: list[di
     def _get(path, params=None, **kwargs):
         assert params.get("_summary") is None  # count comes from the sorted fetch, not a third call
         if params.get("_sort") == "date":
+            assert "date" not in params  # ascending probe stays unfiltered so total counts undated rows
             return {"total": total, "entry": asc_entries}
         if params.get("_sort") == "-date":
+            # The descending probe excludes undated rows server-side (NULLS FIRST).
+            assert params.get("date") == ["ge0001-01-01"]
             return {"total": total, "entry": desc_entries}
         raise AssertionError(f"unexpected params: {params}")
 

--- a/mcp_server/tests/unit/test_tools_patients.py
+++ b/mcp_server/tests/unit/test_tools_patients.py
@@ -48,11 +48,21 @@ def test_build_patient_params_each_arg():
 def test_build_patient_params_birthdate_prefix_passthrough():
     assert build_patient_params(birthdate="ge1980-01-01") == {"birthdate": "ge1980-01-01"}
     assert build_patient_params(birthdate="le2000-12-31") == {"birthdate": "le2000-12-31"}
+    assert build_patient_params(birthdate="gt1980-01-01") == {"birthdate": "gt1980-01-01"}
+    assert build_patient_params(birthdate="lt2000-12-31") == {"birthdate": "lt2000-12-31"}
 
 
 def test_build_patient_params_requires_at_least_one():
     with pytest.raises(ValueError, match="at least one"):
         build_patient_params()
+
+
+def test_build_patient_params_strips_and_rejects_whitespace():
+    # Whitespace-only criteria must not slip past the guard: the server skips
+    # blank filters, which would turn "  " into an unfiltered patient listing.
+    assert build_patient_params(family=" Nguyen ") == {"family": "Nguyen"}
+    with pytest.raises(ValueError, match="at least one"):
+        build_patient_params(name="   ")
 
 
 def test_build_patient_params_rejects_bad_birthdate():
@@ -102,3 +112,28 @@ async def test_search_patients_no_args_raises_before_any_request(auth, fake_clie
     with pytest.raises(ValueError, match="at least one"):
         await search_patients(base_url="http://jhe")
     fake_client.fhir_get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_search_patients_clamps_limit_and_page(auth, fake_client):
+    fake_client.fhir_get.return_value = {"total": 0}  # entry key absent is tolerated
+    result = await search_patients(family="x", limit=5000, page=0, base_url="http://jhe")
+    sent = fake_client.fhir_get.await_args.kwargs["params"]
+    assert sent["_count"] == 1000 and sent["_page"] == 1
+    assert result["page_size"] == 1000 and result["page"] == 1
+    assert result["returned"] == 0 and result["patients"] == []
+    assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_search_patients_has_more_false_when_page_consumes_total(auth, fake_client):
+    fake_client.fhir_get.return_value = {
+        "total": 2,
+        "entry": [
+            _patient_entry("40006", "Nguyen", "May", "1980-01-31"),
+            _patient_entry("40007", "Roe", "Al", "1975-06-02"),
+        ],
+    }
+    result = await search_patients(family="n", limit=2, page=1, base_url="http://jhe")
+    assert result["returned"] == 2
+    assert result["has_more"] is False

--- a/mcp_server/tests/unit/test_tools_patients.py
+++ b/mcp_server/tests/unit/test_tools_patients.py
@@ -70,6 +70,18 @@ def test_build_patient_params_rejects_bad_birthdate():
         build_patient_params(birthdate="Jan 1 1980")
     with pytest.raises(ValueError, match="birthdate"):
         build_patient_params(birthdate="xx1980-01-01")
+    # fromisoformat alone accepts these; the server rejects or misreads them.
+    with pytest.raises(ValueError, match="birthdate"):
+        build_patient_params(birthdate="19800101")
+    with pytest.raises(ValueError, match="birthdate"):
+        build_patient_params(birthdate="ge2026-W14-2")
+
+
+def test_patient_search_result_rejects_entry_without_id():
+    from jhe_mcp.fhir.client import JheClientError
+
+    with pytest.raises(JheClientError, match="Patient entry"):
+        PatientSearchResult.from_fhir_entry({"resource": {"resourceType": "Patient"}})
 
 
 def test_patient_search_result_from_fhir_entry():

--- a/mcp_server/tests/unit/test_tools_patients.py
+++ b/mcp_server/tests/unit/test_tools_patients.py
@@ -1,0 +1,104 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from jhe_mcp.auth.context import AuthContext, set_current_auth
+from jhe_mcp.fhir.models import PatientSearchResult
+from jhe_mcp.tools.patients import build_patient_params, search_patients
+
+
+@pytest.fixture
+def auth():
+    token = set_current_auth(AuthContext(bearer_token="t", subject="u", expires_at=0))
+    yield
+    from jhe_mcp.auth.context import _current
+
+    _current.reset(token)
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    monkeypatch.setattr("jhe_mcp.tools.patients.JheClient", lambda _base_url: client)
+    return client
+
+
+def _patient_entry(pid: str, family: str, given: str, birth: str) -> dict:
+    return {
+        "resource": {
+            "resourceType": "Patient",
+            "id": pid,
+            "name": [{"family": family, "given": [given]}],
+            "birthDate": birth,
+            "telecom": [
+                {"system": "phone", "value": "555-0100", "use": "mobile"},
+                {"system": "email", "value": f"{given.lower()}@example.org", "use": "home"},
+            ],
+        }
+    }
+
+
+def test_build_patient_params_each_arg():
+    assert build_patient_params(name="smi") == {"name": "smi"}
+    assert build_patient_params(family="Nguyen") == {"family": "Nguyen"}
+    assert build_patient_params(given="May") == {"given": "May"}
+    assert build_patient_params(birthdate="1980-01-31") == {"birthdate": "1980-01-31"}
+
+
+def test_build_patient_params_birthdate_prefix_passthrough():
+    assert build_patient_params(birthdate="ge1980-01-01") == {"birthdate": "ge1980-01-01"}
+    assert build_patient_params(birthdate="le2000-12-31") == {"birthdate": "le2000-12-31"}
+
+
+def test_build_patient_params_requires_at_least_one():
+    with pytest.raises(ValueError, match="at least one"):
+        build_patient_params()
+
+
+def test_build_patient_params_rejects_bad_birthdate():
+    with pytest.raises(ValueError, match="birthdate"):
+        build_patient_params(birthdate="Jan 1 1980")
+    with pytest.raises(ValueError, match="birthdate"):
+        build_patient_params(birthdate="xx1980-01-01")
+
+
+def test_patient_search_result_from_fhir_entry():
+    p = PatientSearchResult.from_fhir_entry(_patient_entry("40006", "Nguyen", "May", "1980-01-31"))
+    assert p.patient_id == "40006"
+    assert p.family_name == "Nguyen"
+    assert p.given_name == "May"
+    assert p.birth_date == "1980-01-31"
+    assert p.phone == "555-0100"
+    assert p.email == "may@example.org"
+
+
+def test_patient_search_result_tolerates_missing_fields():
+    p = PatientSearchResult.from_fhir_entry({"resource": {"resourceType": "Patient", "id": "1"}})
+    assert p.patient_id == "1"
+    assert p.family_name is None and p.given_name is None
+    assert p.birth_date is None and p.phone is None and p.email is None
+
+
+@pytest.mark.asyncio
+async def test_search_patients_envelope_and_params(auth, fake_client):
+    fake_client.fhir_get.return_value = {
+        "total": 120,
+        "entry": [_patient_entry("40006", "Nguyen", "May", "1980-01-31")],
+    }
+    result = await search_patients(family="ngu", limit=50, page=1, base_url="http://jhe")
+    assert result["total"] == 120
+    assert result["page"] == 1 and result["page_size"] == 50
+    assert result["returned"] == 1 and result["has_more"] is True
+    assert result["patients"][0]["patient_id"] == "40006"
+    args, kwargs = fake_client.fhir_get.await_args
+    assert args[0] == "Patient"
+    sent = kwargs["params"]
+    assert sent["family"] == "ngu"
+    assert sent["_count"] == 50 and sent["_page"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_patients_no_args_raises_before_any_request(auth, fake_client):
+    with pytest.raises(ValueError, match="at least one"):
+        await search_patients(base_url="http://jhe")
+    fake_client.fhir_get.assert_not_awaited()


### PR DESCRIPTION
## Summary

Updates the MCP server to use the FHIR search features introduced in #667, which it previously worked around client-side:

- **New `search_patients` tool** — patient lookup by `name`/`family`/`given` (case-insensitive prefix match; comma ORs values) and `birthdate` (strict YYYY-MM-DD with optional `ge`/`le`/`gt`/`lt` prefix), returning the standard paged envelope with slim demographics. Whitespace-only criteria are rejected before any request. Authorization is entirely JHE-side, same trust model as the existing tools.
- **Server-side date filtering** — `start`/`end` become repeated FHIR `date` params (`ge…`/`le…`, inclusive at day precision, validated strictly client-side). Removes the workaround that fetched up to 50k records to filter dates in process.
- **Counts via `_summary=count`** — dated and undated counts are a single request.
- **`get_patient_date_range`** — two small sorted probes: ascending (carries the total, which includes undated records) and descending with `date=ge0001-01-01` so records without an effective time — which Postgres sorts first on DESC — can't null out `latest`. Records the OMH parser can't place in time fall back to the FHIR `effective[x]` elements.
- **`order=newest|oldest`** on `get_patient_observations` via `_sort` (default newest-first).
- **`summarize_patient_observations` returns `{truncated, types}`** so a bounded fetch can't present partial counts as complete.
- Shared `fhir/paging.py` (server page cap, bundle validation, page envelope) used by both list tools; malformed upstream Patient entries raise a labeled error; upstream error bodies are capped at 500 chars (full body DEBUG-logged first).
- Docs: README tool list + **deploy order** (backend with #667 must roll out before this server — a stale backend's ignored `_sort` silently corrupts `get_patient_date_range`), UTC-by-default date-comparison note, limit-cap and page-past-end notes in tool docstrings.

## Testing

- `mcp_server`: 175 unit tests pass (was 155); ruff clean. Tests assert the emitted wire params (`date`, `_summary`, `_sort`, `_count`/`_page`), boundary-probe composition (mocks keyed on `_sort`, not call order), strict date validation, truncation cap, and no-request-before-validation.
- Client semantics verified against the server implementation (`core/fhir/search.py`, `fhir_config.json`, `core/views/fhir.py`): repeated `date` params AND, day-precision bounds inclusive, filters apply before `_summary=count`, page cap matches `FHIRBundlePagination.max_page_size`.

## Notes for review

- **Recommend squash-merge**: intermediate commits don't all build individually.
- Adopting `_sort` surfaced two server-side gaps in `_apply_sort` (DESC is NULLS FIRST; no pk tiebreaker) — fixed at the source in #675; this PR also defends client-side.
- No backward-compatibility constraint: the MCP server has no external consumers yet.
- After merge: deploy the JHE backend first, then redeploy the `jhe-mcp` app from `mcp_server/`.