### PR TITLE
fix(fhir): keep undated rows last in _sort and make paging deterministic

### DIFF
--- a/core/fhir/search.py
+++ b/core/fhir/search.py
@@ -363,8 +363,16 @@ def _apply_sort(queryset, resource_type, request, store):
             sort_name, queryset = _annotate_sort_date(queryset, resource_type, store)
             if sort_name is None:
                 continue
-            order.append(("-" if descending else "") + sort_name)
+            # The date sort key is nullable (a row may have no effective time).
+            # Postgres puts NULLs first on DESC by default, which would surface
+            # undated rows as the "newest" — keep them last in either direction.
+            key = F(sort_name)
+            order.append(key.desc(nulls_last=True) if descending else key.asc(nulls_last=True))
         # Unknown sort keys are ignored (FHIR permits a server to ignore unsupported _sort keys).
     if order:
+        # A pk tiebreaker makes the ordering total: LIMIT/OFFSET paging over a
+        # non-unique sort key is otherwise nondeterministic across queries, so
+        # rows sharing a sort value could be skipped or duplicated across pages.
+        order.append("pk")
         queryset = queryset.order_by(*order)
     return queryset

--- a/tests/backend/test_fhir_resource_view.py
+++ b/tests/backend/test_fhir_resource_view.py
@@ -655,3 +655,33 @@ def test_mapped_observation_status_const_and_date(api_client, patient, hr_study)
     # date filters on effective[x].
     assert api_client.get("/FHIR/R5/Observation", {"date": "ge2021-01-01"}).json()["total"] == 2
     assert api_client.get("/FHIR/R5/Observation", {"date": "ge2022-01-01"}).json()["total"] == 0
+
+
+def test_mapped_observation_sort_keeps_undated_rows_last(api_client, patient, hr_study):
+    # A row with no effective time (extract yields all-None) must not surface as the
+    # "newest" record: Postgres sorts NULLs first on DESC unless told otherwise.
+    add_observations(patient=patient, code=Code.HeartRate, n=3)
+    older, newer, undated = Observation.objects.filter(subject_patient=patient).order_by("id")
+    Observation.objects.filter(pk=older.pk).update(effective_date_time="2021-06-15T00:00:00Z")
+    Observation.objects.filter(pk=newer.pk).update(effective_date_time="2022-06-15T00:00:00Z")
+    Observation.objects.filter(pk=undated.pk).update(
+        effective_date_time=None, effective_period_start=None, effective_period_end=None
+    )
+    asc = [e["resource"]["id"] for e in api_client.get("/FHIR/R5/Observation", {"_sort": "date"}).json()["entry"]]
+    assert asc == [str(older.pk), str(newer.pk), str(undated.pk)]
+    desc = [e["resource"]["id"] for e in api_client.get("/FHIR/R5/Observation", {"_sort": "-date"}).json()["entry"]]
+    assert desc == [str(newer.pk), str(older.pk), str(undated.pk)]
+
+
+def test_mapped_observation_sort_pages_are_stable_on_ties(api_client, patient, hr_study):
+    # Identical sort keys need a tiebreaker for LIMIT/OFFSET paging to be a
+    # partition: without one, rows sharing a timestamp can repeat or vanish
+    # across pages.
+    add_observations(patient=patient, code=Code.HeartRate, n=4)
+    Observation.objects.filter(subject_patient=patient).update(effective_date_time="2021-06-15T00:00:00Z")
+    seen = []
+    for page in (1, 2):
+        bundle = api_client.get("/FHIR/R5/Observation", {"_sort": "date", "_count": 2, "_page": page}).json()
+        seen += [e["resource"]["id"] for e in bundle["entry"]]
+    assert len(seen) == 4
+    assert len(set(seen)) == 4


### PR DESCRIPTION
## Summary

Two small gaps in the `_sort` support introduced in #667, found while adopting it in the MCP server (#674):

1. **Descending date sort surfaced undated rows first.** The date sort key (`effective_date_time`/`effective_period_start` on the mapped store, the JSONB path on the aux store) is nullable, and Postgres orders NULLs first on `DESC` — so `_sort=-date` returned records with no effective time as the "newest". Now sorted with `nulls_last` in both directions.
2. **No tiebreaker → unstable pagination under `_sort`.** `LIMIT`/`OFFSET` paging over a non-unique sort key is nondeterministic across queries, so rows sharing a timestamp could be skipped or duplicated across pages. A `pk` tiebreaker is now appended whenever `_sort` applies, making the ordering total.

## Testing

- New backend tests: `test_mapped_observation_sort_keeps_undated_rows_last` (fails without the fix — undated row previously sorted first on `-date`) and `test_mapped_observation_sort_pages_are_stable_on_ties`. Also covers the previously untested mapped-store `_sort` path (only the aux store's sort had coverage).
- Full suite: 966 passed, 28 skipped (contract tests excluded as in CI).

#674's client mitigates the NULL case on its side either way; this fixes it at the source.