### PR TITLE
fix(models): import jsonschema ValidationError in observation.py

### DIFF
--- a/core/models/observation.py
+++ b/core/models/observation.py
@@ -9,6 +9,7 @@ from django.db.models import F, Q
 from django.db.utils import IntegrityError
 from django.shortcuts import get_object_or_404
 from fhir.resources.observation import Observation as FHIRObservation
+from jsonschema.exceptions import ValidationError
 
 from core.fhir.effective_time_frame import extract_effective_time_frame
 from core.fhir.scope import authorize_practitioner_scope, resolve_fhir_user


### PR DESCRIPTION
Main's backend CI is red since #509 merged (de9d6d9): `Observation.clean()` catches jsonschema's `ValidationError`, but the `validate_with_registry` refactor left that name unimported in `core/models/observation.py`. Any OMH schema-validation failure now raises `NameError` → 500 from the admin (regressing the #527 inline-field-error fix) and from every validating write path. `test_admin_add_invalid_omh_data_renders_field_error_not_500` catches it.

One-line fix: import `jsonschema.exceptions.ValidationError`. Full backend suite passes locally with this applied (939 passed).

cc @minrk (#509)