### PR TITLE
fix(fhir-import): keep repeating primitives as lists; surface per-record import errors

### DIFF
--- a/core/fhir/cross_version.py
+++ b/core/fhir/cross_version.py
@@ -146,7 +146,7 @@ class _Engine:
         if transform == "copy":
             value = self._param_value(target["parameter"][0], svars, tvars)
             if element is not None and value is not None:
-                context.value[element] = value
+                self._assign(context, element, value)
             return
 
         if transform == "translate":
@@ -154,7 +154,7 @@ class _Engine:
             code = self._param_value(params[0], svars, tvars)
             url = params[1].get("valueString") if len(params) > 1 else None
             if element is not None and code is not None:
-                context.value[element] = self.maps.translate(url, code)
+                self._assign(context, element, self.maps.translate(url, code))
             return
 
         if transform in (None, "create") and element is not None:
@@ -164,6 +164,17 @@ class _Engine:
             return
 
         # ``evaluate`` (Subscription only) and any other transform are unsupported -> skipped.
+
+    @staticmethod
+    def _assign(context, element, value):
+        # A rule over a repeating source runs once per item (see _run_rule), so a repeating
+        # target must append -- plain assignment keeps only the last item and mistypes the
+        # element as a scalar (e.g. R4 AllergyIntolerance.category ["medication", "food"]
+        # collapsed to "food", failing R5 validation).
+        if is_list(context.model, element) and not isinstance(value, list):
+            context.value.setdefault(element, []).append(value)
+        else:
+            context.value[element] = value
 
     def _apply_create(self, target, svars, tvars, context, element):
         # The variable a ``create`` binds carries the *source* element into the target under the

--- a/core/fhir/cross_version.py
+++ b/core/fhir/cross_version.py
@@ -144,9 +144,18 @@ class _Engine:
         element = target.get("element")
 
         if transform == "copy":
-            value = self._param_value(target["parameter"][0], svars, tvars)
+            param = target["parameter"][0]
+            value = self._param_value(param, svars, tvars)
             if element is not None and value is not None:
-                self._assign(context, element, value)
+                source_var = svars.get(param["valueId"]) if "valueId" in param else None
+                json_key, child_model = _target_key(context.model, element, source_var)
+                # A bare code copied into a CodeableConcept-typed element (e.g. the
+                # DocumentReference4to5 map's attester.mode = "professional") is wrapped
+                # rather than assigned raw, which would fail R5 validation. No coding
+                # system is available from the map, so the code lands in ``text``.
+                if isinstance(value, str) and getattr(child_model, "__name__", None) == "CodeableConcept":
+                    value = {"text": value}
+                self._assign(context, json_key, value)
             return
 
         if transform == "translate":

--- a/core/fhir/cross_version.py
+++ b/core/fhir/cross_version.py
@@ -172,7 +172,11 @@ class _Engine:
         # element as a scalar (e.g. R4 AllergyIntolerance.category ["medication", "food"]
         # collapsed to "food", failing R5 validation).
         if is_list(context.model, element) and not isinstance(value, list):
-            context.value.setdefault(element, []).append(value)
+            existing = context.value.setdefault(element, [])
+            if isinstance(existing, list):
+                existing.append(value)
+            else:
+                context.value[element] = [existing, value]
         else:
             context.value[element] = value
 

--- a/core/static/clients/patient-access/js/client-patient-access.js
+++ b/core/static/clients/patient-access/js/client-patient-access.js
@@ -173,11 +173,13 @@ async function paPullResourceType(client, jheToken, sourceId, pull, iss) {
       : await client.patient.request(pull.query, { pageLimit: 0, flat: true });
     resources = pull.single ? (result ? [result] : []) : result || [];
   } catch (e) {
-    return { written: 0, failed: 0, error: e && e.message ? e.message : String(e) };
+    return { written: 0, failed: 0, error: e && e.message ? e.message : String(e), reasons: {} };
   }
   var written = 0;
   var failed = 0;
-  var reasons = {}; // distinct failure text -> count, so 45 identical errors read as one line
+  // Distinct failure text -> count, so 45 identical errors read as one line. Null prototype:
+  // a diagnostics string like "__proto__" or "constructor" must count as a plain key.
+  var reasons = Object.create(null);
   for (var i = 0; i < resources.length; i++) {
     var resource = resources[i];
     if (!resource || resource.resourceType !== pull.type) continue;
@@ -345,8 +347,16 @@ async function finishPatientAccessConnect(out, config) {
     out.textContent += "\n  saved " + result.written + " record(s)";
     if (result.failed) {
       out.textContent += "\n  " + result.failed + " record(s) could not be saved:";
-      for (var reason in result.reasons) {
+      // Validation messages can embed record values, making every reason distinct — cap the
+      // list at the 5 most frequent so one bad type cannot flood the page.
+      var reasonList = Object.keys(result.reasons).sort(function (a, b) {
+        return result.reasons[b] - result.reasons[a];
+      });
+      reasonList.slice(0, 5).forEach(function (reason) {
         out.textContent += "\n    - " + reason + " (x" + result.reasons[reason] + ")";
+      });
+      if (reasonList.length > 5) {
+        out.textContent += "\n    ... and " + (reasonList.length - 5) + " more distinct error(s)";
       }
     }
     summary.push(pull.label + ": " + result.written + (result.failed ? " (" + result.failed + " failed)" : ""));

--- a/core/static/clients/patient-access/js/client-patient-access.js
+++ b/core/static/clients/patient-access/js/client-patient-access.js
@@ -115,9 +115,22 @@ function paSanitizeResource(resource, iss) {
   return resource;
 }
 
+// The error text of a failed import entry, from the OperationOutcome the endpoint puts at
+// response.outcome (the first error/fatal issue's diagnostics). Null when there is none.
+function paEntryFailureReason(entry) {
+  var issues = (entry && entry.response && entry.response.outcome && entry.response.outcome.issue) || [];
+  for (var i = 0; i < issues.length; i++) {
+    if (issues[i].severity === "error" || issues[i].severity === "fatal") {
+      return issues[i].diagnostics || (issues[i].details && issues[i].details.text) || issues[i].code || "unknown error";
+    }
+  }
+  return null;
+}
+
 // POST one R4 resource to the JHE R4 import endpoint (converts R4->R5, then creates).
 // The endpoint returns HTTP 200 with a batch-response Bundle even when the single entry
 // failed, so success is the entry's own create status (2xx), not just response.ok.
+// Returns {ok, reason}: reason carries the entry's OperationOutcome error on failure.
 async function paWriteResource(jheToken, sourceId, resourceType, resource) {
   var response = await fetch(IMPORT_ENDPOINT + resourceType, {
     method: "POST",
@@ -129,11 +142,12 @@ async function paWriteResource(jheToken, sourceId, resourceType, resource) {
     },
     body: JSON.stringify(resource),
   });
-  if (!response.ok) return false;
+  if (!response.ok) return { ok: false, reason: "HTTP " + response.status };
   var bundle = await response.json();
   var entry = bundle && bundle.entry && bundle.entry[0];
   var status = entry && entry.response && entry.response.status;
-  return typeof status === "string" && status.charAt(0) === "2";
+  var ok = typeof status === "string" && status.charAt(0) === "2";
+  return { ok: ok, reason: ok ? null : paEntryFailureReason(entry) || status || "unknown error" };
 }
 
 // USCDI resources pulled for the demo phenotype. `single` reads one instance (Patient),
@@ -163,15 +177,20 @@ async function paPullResourceType(client, jheToken, sourceId, pull, iss) {
   }
   var written = 0;
   var failed = 0;
+  var reasons = {}; // distinct failure text -> count, so 45 identical errors read as one line
   for (var i = 0; i < resources.length; i++) {
     var resource = resources[i];
     if (!resource || resource.resourceType !== pull.type) continue;
     paSanitizeResource(resource, iss);
-    var ok = await paWriteResource(jheToken, sourceId, pull.type, resource);
-    if (ok) written++;
-    else failed++;
+    var write = await paWriteResource(jheToken, sourceId, pull.type, resource);
+    if (write.ok) written++;
+    else {
+      failed++;
+      var reason = write.reason || "unknown error";
+      reasons[reason] = (reasons[reason] || 0) + 1;
+    }
   }
-  return { written: written, failed: failed, error: null };
+  return { written: written, failed: failed, error: null, reasons: reasons };
 }
 
 // Search hospital brands for the picker. Returns an array of facility rows (or []).
@@ -324,6 +343,12 @@ async function finishPatientAccessConnect(out, config) {
       continue;
     }
     out.textContent += "\n  saved " + result.written + " record(s)";
+    if (result.failed) {
+      out.textContent += "\n  " + result.failed + " record(s) could not be saved:";
+      for (var reason in result.reasons) {
+        out.textContent += "\n    - " + reason + " (x" + result.reasons[reason] + ")";
+      }
+    }
     summary.push(pull.label + ": " + result.written + (result.failed ? " (" + result.failed + " failed)" : ""));
   }
 

--- a/core/static/clients/patient-access/js/client-patient-access.js
+++ b/core/static/clients/patient-access/js/client-patient-access.js
@@ -142,7 +142,16 @@ async function paWriteResource(jheToken, sourceId, resourceType, resource) {
     },
     body: JSON.stringify(resource),
   });
-  if (!response.ok) return { ok: false, reason: "HTTP " + response.status };
+  if (!response.ok) {
+    // Keep the response body: a scope rejection reads as a bare 403 without it.
+    var detail = "";
+    try {
+      detail = (await response.text()).slice(0, 300);
+    } catch (e) {
+      /* body unreadable; status alone will have to do */
+    }
+    return { ok: false, reason: "HTTP " + response.status + (detail ? ": " + detail : "") };
+  }
   var bundle = await response.json();
   var entry = bundle && bundle.entry && bundle.entry[0];
   var status = entry && entry.response && entry.response.status;
@@ -347,6 +356,9 @@ async function finishPatientAccessConnect(out, config) {
     out.textContent += "\n  saved " + result.written + " record(s)";
     if (result.failed) {
       out.textContent += "\n  " + result.failed + " record(s) could not be saved:";
+      // The on-screen list below is capped; log the complete map so a console capture
+      // keeps every distinct reason.
+      console.error("Patient Access import failures for " + pull.label + ":", result.reasons);
       // Validation messages can embed record values, making every reason distinct — cap the
       // list at the 5 most frequent so one bad type cannot flood the page.
       var reasonList = Object.keys(result.reasons).sort(function (a, b) {

--- a/data/fhir/fhir-cross-version-patches/StructureMap-DocumentReference4to5-attester.json
+++ b/data/fhir/fhir-cross-version-patches/StructureMap-DocumentReference4to5-attester.json
@@ -1,0 +1,56 @@
+{
+  "resourceType": "StructureMap",
+  "name": "DocumentReference4to5LocalPatches",
+  "description": "Local rule patches over the official DocumentReference4to5 map (see cross_version_maps._apply_patches). The official map splits authenticator across two rules that each create their own tgt.attester, yielding a mode-only attester plus a party-only attester; R5 requires mode on every attester, so every Epic clinical-note document failed import. Merged here into one rule producing a single attester carrying both mode and party.",
+  "group": [
+    {
+      "name": "DocumentReference",
+      "rule": [
+        {
+          "name": "authenticator",
+          "documentation": "Single attester with mode + party. The literal mode code is wrapped into a CodeableConcept by the engine's copy transform.",
+          "source": [
+            {
+              "context": "src",
+              "type": "Reference",
+              "element": "authenticator",
+              "variable": "s"
+            }
+          ],
+          "target": [
+            {
+              "context": "tgt",
+              "element": "attester",
+              "variable": "t"
+            },
+            {
+              "context": "t",
+              "element": "mode",
+              "transform": "copy",
+              "parameter": [{ "valueString": "professional" }]
+            },
+            {
+              "context": "t",
+              "element": "party",
+              "transform": "copy",
+              "parameter": [{ "valueId": "s" }]
+            }
+          ]
+        },
+        {
+          "name": "authenticatorReference",
+          "documentation": "Neutralized: its work is folded into the 'authenticator' rule above so only one attester is created.",
+          "source": [
+            {
+              "context": "src",
+              "type": "Reference",
+              "element": "authenticator",
+              "variable": "s"
+            }
+          ],
+          "target": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/backend/test_fhir_r4_import.py
+++ b/tests/backend/test_fhir_r4_import.py
@@ -243,6 +243,40 @@ def test_engine_assign_semantics_directly():
     assert ctx.value["criticality"] == "high"
 
 
+def test_engine_copy_flattens_choice_target_and_wraps_codeableconcept():
+    # Two DocumentReference4to5 gaps found via live Epic pulls (every clinical-note
+    # document failed R5 validation):
+    # 1. R4 ``content.format`` (Coding) copies into R5 ``content.profile.value[x]`` -- a
+    #    choice element the copy transform must flatten to ``valueCoding``, exactly as
+    #    ``create`` targets already do.
+    # 2. R4 ``authenticator`` maps to an attester whose ``mode`` the map fills with the
+    #    bare code "professional", but R5 mode is a CodeableConcept -- the copy wraps it.
+    r4 = {
+        "resourceType": "DocumentReference",
+        "status": "current",
+        "content": [
+            {
+                "attachment": {"contentType": "text/html", "url": "Binary/b1"},
+                "format": {
+                    "system": "http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem",
+                    "code": "urn:ihe:iti:xds:2017:mimeTypeSufficient",
+                },
+            }
+        ],
+        "authenticator": {"reference": "Practitioner/pr1"},
+    }
+    out = transform_to_r5("DocumentReference", r4)
+    validate_fhir_resource("DocumentReference", out)
+    profile = out["content"][0]["profile"][0]
+    assert profile["valueCoding"]["code"] == "urn:ihe:iti:xds:2017:mimeTypeSufficient"
+    # The local patch map merges the official map's two attester rules into one entry
+    # carrying both mode and party (data/fhir/fhir-cross-version-patches).
+    assert len(out["attester"]) == 1
+    attester = out["attester"][0]
+    assert attester["party"]["reference"] == "Practitioner/pr1"
+    assert attester["mode"] == {"text": "professional"}
+
+
 def test_engine_parenthesised_condition():
     # Newer maps parenthesise rule conditions (`where (s = 'allergy')`); AllergyIntolerance.type is
     # mapped only through such a rule, so a parser that cannot read them drops the field.

--- a/tests/backend/test_fhir_r4_import.py
+++ b/tests/backend/test_fhir_r4_import.py
@@ -243,6 +243,53 @@ def test_engine_assign_semantics_directly():
     assert ctx.value["criticality"] == "high"
 
 
+def test_engine_translate_transform_appends_on_repeating_element():
+    # translate shares _assign with copy, but no pack map translates onto a repeating
+    # element today, so drive the engine with a minimal synthetic map: both source codes
+    # must survive a translate-transform rule over a repeating element (plain assignment
+    # would keep only the last and mistype the element as a scalar).
+    from core.fhir.cross_version import _Engine
+
+    group = {
+        "name": "AllergyIntolerance",
+        "input": [{"name": "src", "mode": "source"}, {"name": "tgt", "mode": "target"}],
+        "rule": [
+            {
+                "name": "category",
+                "source": [{"context": "src", "element": "category", "variable": "v", "type": "code"}],
+                "target": [
+                    {
+                        "context": "tgt",
+                        "element": "category",
+                        "transform": "translate",
+                        "parameter": [{"valueId": "v"}, {"valueString": "http://example.org/cat4to5"}],
+                    }
+                ],
+            },
+            {
+                "name": "patient",  # R5-required; carried over so the output validates
+                "source": [{"context": "src", "element": "patient", "variable": "p"}],
+                "target": [
+                    {"context": "tgt", "element": "patient", "transform": "copy", "parameter": [{"valueId": "p"}]}
+                ],
+            },
+        ],
+    }
+
+    class _StubMaps:
+        def group_for(self, name):
+            return group if name == "AllergyIntolerance" else None
+
+        def translate(self, url, code):
+            assert url == "http://example.org/cat4to5"
+            return {"med": "medication", "fd": "food"}[code]
+
+    r4 = {"resourceType": "AllergyIntolerance", "category": ["med", "fd"], "patient": {"reference": "Patient/p1"}}
+    out = _Engine(maps=_StubMaps()).transform("AllergyIntolerance", r4)
+    validate_fhir_resource("AllergyIntolerance", out)
+    assert out["category"] == ["medication", "food"]
+
+
 def test_engine_copy_flattens_choice_target_and_wraps_codeableconcept():
     # Two DocumentReference4to5 gaps found via live Epic pulls (every clinical-note
     # document failed R5 validation):

--- a/tests/backend/test_fhir_r4_import.py
+++ b/tests/backend/test_fhir_r4_import.py
@@ -217,6 +217,32 @@ def test_engine_copy_transform_keeps_repeating_primitive_list():
     assert out["category"] == ["medication", "food"]
 
 
+def test_engine_assign_semantics_directly():
+    # _assign backs both the copy and translate transforms: repeating target -> append per
+    # iterated source item; scalar target or already-a-list value -> plain assignment; a
+    # scalar left under a repeating key by any earlier rule is promoted to a list.
+    from fhir.resources.allergyintolerance import AllergyIntolerance as R5A
+
+    from core.fhir.cross_version import _Engine, _Var
+
+    ctx = _Var({}, R5A)
+    _Engine._assign(ctx, "category", "medication")
+    _Engine._assign(ctx, "category", "food")
+    assert ctx.value["category"] == ["medication", "food"]
+
+    ctx = _Var({}, R5A)
+    _Engine._assign(ctx, "category", ["medication", "food"])  # pre-built list assigns wholesale
+    assert ctx.value["category"] == ["medication", "food"]
+
+    ctx = _Var({"category": "medication"}, R5A)  # scalar residue under a repeating key
+    _Engine._assign(ctx, "category", "food")
+    assert ctx.value["category"] == ["medication", "food"]
+
+    ctx = _Var({}, R5A)
+    _Engine._assign(ctx, "criticality", "high")  # scalar element: plain assignment
+    assert ctx.value["criticality"] == "high"
+
+
 def test_engine_parenthesised_condition():
     # Newer maps parenthesise rule conditions (`where (s = 'allergy')`); AllergyIntolerance.type is
     # mapped only through such a rule, so a parser that cannot read them drops the field.
@@ -430,6 +456,19 @@ def test_import_error_entry_still_reports_dropped_fields(api_client, patient, fh
     severities = [i["severity"] for i in issues]
     assert "error" in severities
     assert any(i["severity"] == "warning" and i["expression"] == ["Coverage.payor"] for i in issues)
+
+
+def test_import_error_issue_carries_diagnostics_string(api_client, fhir_source):
+    # The patient-access client renders entry.response.outcome.issue[].diagnostics for failed
+    # records (paEntryFailureReason). Pin the contract: the first error issue is severity
+    # "error" with a non-empty diagnostics string.
+    # Coverage reliably fails R5 validation (kind is new-in-R5 and mandatory; no map rule).
+    r4 = {"resourceType": "Coverage", "status": "active", "beneficiary": {"reference": "Patient/p1"}}
+    r = api_client.post("/fhir-import/R4/Coverage", r4, **_src(fhir_source))
+    assert r.status_code == 200, r.text
+    issue = r.json()["entry"][0]["response"]["outcome"]["issue"][0]
+    assert issue["severity"] == "error"
+    assert isinstance(issue["diagnostics"], str) and issue["diagnostics"]
 
 
 def test_import_get_not_allowed(api_client, fhir_source):

--- a/tests/backend/test_fhir_r4_import.py
+++ b/tests/backend/test_fhir_r4_import.py
@@ -200,6 +200,23 @@ def test_engine_implicit_datatype_dispatch():
     assert component["referenceRange"][0]["low"] == {"value": 90, "unit": "mmHg"}
 
 
+def test_engine_copy_transform_keeps_repeating_primitive_list():
+    # AllergyIntolerance.category maps through a plain ``copy`` target (unlike Patient's
+    # repeating primitives, which go through ``create``). The rule runs once per source item,
+    # so a copy that assigns instead of appending keeps only the last item and mistypes the
+    # element as a scalar -- every Epic allergy carries a category, so all of them failed R5
+    # validation with "value is not a valid list".
+    r4 = {
+        "resourceType": "AllergyIntolerance",
+        "category": ["medication", "food"],
+        "code": {"text": "PENICILLIN G"},
+        "patient": {"reference": "Patient/p1"},
+    }
+    out = transform_to_r5("AllergyIntolerance", r4)
+    validate_fhir_resource("AllergyIntolerance", out)
+    assert out["category"] == ["medication", "food"]
+
+
 def test_engine_parenthesised_condition():
     # Newer maps parenthesise rule conditions (`where (s = 'allergy')`); AllergyIntolerance.type is
     # mapped only through such a rule, so a parser that cannot read them drops the field.

--- a/tests/frontend/tests/patient-access-pull.test.js
+++ b/tests/frontend/tests/patient-access-pull.test.js
@@ -67,6 +67,21 @@ describe("paWriteResource", () => {
       reason: "400 invalid",
     });
   });
+
+  test("keeps the response body in the reason for a transport-level failure", async () => {
+    // A scope rejection must not read as a bare 403 — the body says which scope.
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('{"detail":"missing patient/Condition.read scope"}'),
+      }),
+    );
+    expect(await window.paWriteResource("tok", "1", "Condition", {})).toEqual({
+      ok: false,
+      reason: 'HTTP 403: {"detail":"missing patient/Condition.read scope"}',
+    });
+  });
 });
 
 describe("paPullResourceType", () => {

--- a/tests/frontend/tests/patient-access-pull.test.js
+++ b/tests/frontend/tests/patient-access-pull.test.js
@@ -86,7 +86,7 @@ describe("paPullResourceType", () => {
   test("a pull failure is isolated, not thrown", async () => {
     const client = { patient: { id: "epic-1", request: jest.fn(() => Promise.reject(new Error("timeout"))) } };
     const r = await window.paPullResourceType(client, "tok", "1", CONDITION_PULL, "iss");
-    expect(r).toEqual({ written: 0, failed: 0, error: "timeout" });
+    expect(r).toEqual({ written: 0, failed: 0, error: "timeout", reasons: {} });
   });
 
   test("a per-entry import error counts as failed and aggregates the distinct reason", async () => {

--- a/tests/frontend/tests/patient-access-pull.test.js
+++ b/tests/frontend/tests/patient-access-pull.test.js
@@ -8,11 +8,21 @@ beforeAll(() => {
 // Epic serves R4; JHE validates R5. Writes must go through the /fhir-import/R4/ endpoint,
 // which converts R4->R5 and returns a batch-response Bundle whose single entry carries the
 // real create status. A 200 HTTP response can still contain a per-entry 400.
-function importResponse(entryStatus) {
+function importResponse(entryStatus, outcome) {
   return Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ resourceType: "Bundle", type: "batch-response", entry: [{ response: { status: entryStatus } }] }),
+    json: () =>
+      Promise.resolve({
+        resourceType: "Bundle",
+        type: "batch-response",
+        entry: [{ response: { status: entryStatus, outcome: outcome } }],
+      }),
   });
+}
+
+// The endpoint's failure outcome: the create-path error as an OperationOutcome issue.
+function errorOutcome(diagnostics) {
+  return { resourceType: "OperationOutcome", issue: [{ severity: "error", code: "invalid", diagnostics: diagnostics }] };
 }
 
 beforeEach(() => {
@@ -37,14 +47,25 @@ describe("paWriteResource", () => {
     expect(url).not.toContain("/FHIR/R5/");
   });
 
-  test("returns true when the import entry status is 2xx", async () => {
+  test("reports ok when the import entry status is 2xx", async () => {
     global.fetch = jest.fn(() => importResponse("201 Created"));
-    expect(await window.paWriteResource("tok", "1", "Condition", {})).toBe(true);
+    expect(await window.paWriteResource("tok", "1", "Condition", {})).toEqual({ ok: true, reason: null });
   });
 
-  test("returns false when the import entry status is 4xx (conversion/validation failed)", async () => {
+  test("reports the entry's OperationOutcome error when the status is 4xx", async () => {
+    global.fetch = jest.fn(() => importResponse("400 invalid", errorOutcome("clinicalStatus: field required")));
+    expect(await window.paWriteResource("tok", "1", "MedicationRequest", {})).toEqual({
+      ok: false,
+      reason: "clinicalStatus: field required",
+    });
+  });
+
+  test("falls back to the entry status when the outcome carries no error issue", async () => {
     global.fetch = jest.fn(() => importResponse("400 invalid"));
-    expect(await window.paWriteResource("tok", "1", "MedicationRequest", {})).toBe(false);
+    expect(await window.paWriteResource("tok", "1", "MedicationRequest", {})).toEqual({
+      ok: false,
+      reason: "400 invalid",
+    });
   });
 });
 
@@ -52,7 +73,7 @@ describe("paPullResourceType", () => {
   test("writes each matching resource and counts them", async () => {
     const client = fakeClient([{ resourceType: "Condition" }, { resourceType: "Condition" }]);
     const r = await window.paPullResourceType(client, "tok", "1", CONDITION_PULL, "iss");
-    expect(r).toEqual({ written: 2, failed: 0, error: null });
+    expect(r).toEqual({ written: 2, failed: 0, error: null, reasons: {} });
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
@@ -68,11 +89,16 @@ describe("paPullResourceType", () => {
     expect(r).toEqual({ written: 0, failed: 0, error: "timeout" });
   });
 
-  test("a per-entry import error counts as failed, not written", async () => {
-    global.fetch = jest.fn(() => importResponse("400 invalid"));
-    const client = fakeClient([{ resourceType: "Condition" }]);
+  test("a per-entry import error counts as failed and aggregates the distinct reason", async () => {
+    global.fetch = jest.fn(() => importResponse("400 invalid", errorOutcome("clinicalStatus: field required")));
+    const client = fakeClient([{ resourceType: "Condition" }, { resourceType: "Condition" }]);
     const r = await window.paPullResourceType(client, "tok", "1", CONDITION_PULL, "iss");
-    expect(r).toEqual({ written: 0, failed: 1, error: null });
+    expect(r).toEqual({
+      written: 0,
+      failed: 2,
+      error: null,
+      reasons: { "clinicalStatus: field required": 2 },
+    });
   });
 
   test("single read uses a plain instance read (not a patient-compartment search)", async () => {


### PR DESCRIPTION
> **Design + build manifest: #712** — what surfaced these fixes (live Epic-sandbox testing), the debugging, and the deferred `Condition.clinicalStatus` policy call. Worth reading before the diff.

Follow-up to #671, from live end-to-end testing of the patient-access sync against the Epic sandbox (`jhe.fly.dev`, Epic test patient): **Conditions: 22 saved (45 failed), Allergies: 0 saved (3 failed)** with no visible reason.

## Fix 1: cross-version engine collapsed repeating primitives (all allergy imports failed)

`_run_rule` iterates a repeating source element one item at a time, but the `copy`/`translate` targets assigned each item to the target slot — so `AllergyIntolerance.category ["medication", "food"]` became the scalar `"food"`, and every allergy then failed R5 validation with `category: value is not a valid list`. (Epic emits a category on every allergy, hence 3/3 failed.)

Both transforms now append when the target element repeats, using the same `is_list` dispatch `_apply_create` already used. Regression test: `test_engine_copy_transform_keeps_repeating_primitive_list`.

## Fix 2: the callback UI discarded the per-record error the endpoint already returns

The import endpoint puts the create-path error in each entry's `response.outcome` (OperationOutcome), but the client only counted failures — making the 45 Condition failures undiagnosable without checking out the branch and replaying the conversion. `paWriteResource` now returns `{ok, reason}` and the callback page lists each distinct failure reason with a count, e.g.:

```
Fetching Conditions from Patient Access...
  saved 22 record(s)
  45 record(s) could not be saved:
    - Invalid FHIR Condition: clinicalStatus — field required (x45)
```

## Explicitly deferred (needs a policy call, not a code fix)

The 45 Condition failures themselves are **R5 making `Condition.clinicalStatus` mandatory** (optional in R4 — Epic returns many encounter-diagnosis/health-concern Conditions without it). Options are synthesizing `condition-clinical|unknown` during import vs. continuing to reject; with this PR the UI at least says why. Left for a follow-up issue.

## Verification
- Backend: 978 passed (incl. 31 in `test_fhir_r4_import.py`)
- Frontend: 48 passed (jest), incl. new coverage for reason extraction/aggregation
- Manual repro of the exact sandbox failure shapes through `transform_to_r5` + `validate_fhir_resource`: category list now survives and validates

## Staff-review hardening pass (second commit)
Three-lens agent review applied: `_assign` now promotes scalar residue under a repeating key (with direct unit coverage of both dispatch semantics); a backend test pins the OperationOutcome error contract the client parses (severity `error` + diagnostics string); the reasons accumulator uses a null prototype; the error-path result shape gains `reasons: {}`; and the callback caps rendered failure reasons at the 5 most frequent. Backend 33/33 in the import file, jest green.
