### PR TITLE
feat(mcp): capability-aware MCP server (CapabilityStatement digest + search preflight)

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -78,6 +78,7 @@ The MCP server exposes the following tools to LLM clients. Every tool runs as th
 - **Patients:** `search_patients`, `get_patient_demographics`, `get_patient_date_range`
 - **Observations:** `count_patient_observations`, `count_study_observations`, `summarize_patient_observations`, `get_patient_observations`
 - **OMH schemas:** `get_omh_schema` (schemas are also browsable as resources at `omh://schema/<name>`)
+- **Capabilities:** `get_server_capabilities` (digest of the instance's `/FHIR/R5/metadata`)
 
 The observation and patient-search tools rely on JHE's FHIR search support (`date`, `_summary=count`, `_sort`, and the Patient search params introduced in #667); a JHE without it silently ignores unknown search params, so date windows and ordering would not be applied. **Deploy order matters:** roll out the JHE backend with #667 before (never after) deploying this server — against a stale backend the ignored `_sort` silently corrupts `get_patient_date_range`, it doesn't just widen date windows.
 

--- a/mcp_server/src/jhe_mcp/core.py
+++ b/mcp_server/src/jhe_mcp/core.py
@@ -12,6 +12,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from jhe_mcp.auth.oauth_flow import AuthenticationRequired
 from jhe_mcp.auth.token_verifier import JheTokenVerifier
 from jhe_mcp.config import Settings
+from jhe_mcp.fhir.capabilities import get_capabilities
 from jhe_mcp.omh_registry import all_schema_ids, all_short_names, load_schema, short_name
 from jhe_mcp.tools import observation_counts, observation_views
 from jhe_mcp.tools import patients as patient_tools
@@ -40,6 +41,7 @@ Tools by purpose:
 - Observations: count_patient_observations, count_study_observations,
   summarize_patient_observations, get_patient_observations
 - OMH schemas: get_omh_schema(name); also browsable as resources at omh://schema/<name>
+- Capabilities: get_server_capabilities
 
 Key behaviors:
 - Dates are OPTIONAL on observation tools. Pass start/end as YYYY-MM-DD (inclusive)
@@ -64,6 +66,8 @@ Efficient workflows — do NOT dump or page through records just to count or fin
   ({truncated, types: {type: {count, earliest, latest}}}) for the overview, then page
   get_patient_observations (slim); fetch verbosity="full" only for specific records.
 - Need a data type's schema: get_omh_schema("blood-glucose"), etc.
+- Unsure whether this JHE instance supports a resource or search param?
+  get_server_capabilities returns its CapabilityStatement digest.
 """
 
 
@@ -137,6 +141,31 @@ def build_server(
             if short_name(sid) == name:
                 return load_schema(sid)
         return {"error": f"Unknown schema name {name!r}", "known": all_short_names()}
+
+    @mcp.tool()
+    async def get_server_capabilities() -> dict | str:
+        """What this JHE instance supports, from its FHIR CapabilityStatement.
+
+        Returns {available, fhir_version, resources: {type: {interactions,
+        search_params}}}. available=false means the instance predates the
+        /FHIR/R5/metadata endpoint; tools then assume full support.
+        """
+        if auth_msg := await _before():
+            return auth_msg
+        caps = await get_capabilities(base_url)
+        if caps is None:
+            return {"available": False, "reason": "This JHE instance does not expose /FHIR/R5/metadata."}
+        return {
+            "available": True,
+            "fhir_version": caps.fhir_version,
+            "resources": {
+                resource_type: {
+                    "interactions": sorted(capability.interactions),
+                    "search_params": capability.search_params,
+                }
+                for resource_type, capability in sorted(caps.resources.items())
+            },
+        }
 
     @mcp.tool()
     async def get_study_count() -> int | str:

--- a/mcp_server/src/jhe_mcp/fhir/capabilities.py
+++ b/mcp_server/src/jhe_mcp/fhir/capabilities.py
@@ -1,0 +1,116 @@
+"""Fetch and digest a JHE instance's FHIR CapabilityStatement (GET /FHIR/R5/metadata).
+
+The metadata endpoint is public by FHIR spec, so the fetch is deliberately
+unauthenticated -- no bearer is ever attached. Results (including "endpoint
+absent") are cached per base_url for a short TTL: capabilities only change
+when the backend deploys, and an old JHE without the endpoint must not be
+re-probed on every tool call.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 300.0
+_FETCH_TIMEOUT = 5.0
+# FHIR RESTful interaction codes -> the shorter names JHE's config uses.
+_INTERACTION_NAMES = {"search-type": "search"}
+
+_cache: dict[str, tuple[float, ServerCapabilities | None]] = {}
+
+
+class ResourceCapability(BaseModel):
+    interactions: set[str] = Field(default_factory=set)
+    search_params: dict[str, str] = Field(default_factory=dict)
+
+
+class ServerCapabilities(BaseModel):
+    fhir_version: str | None = None
+    resources: dict[str, ResourceCapability] = Field(default_factory=dict)
+
+    @classmethod
+    def from_capability_statement(cls, statement: Any) -> ServerCapabilities | None:
+        """Digest a CapabilityStatement dict; None when the body isn't one."""
+        if not isinstance(statement, dict) or statement.get("resourceType") != "CapabilityStatement":
+            return None
+        resources: dict[str, ResourceCapability] = {}
+        for rest in statement.get("rest") or []:
+            for resource in rest.get("resource") or []:
+                resource_type = resource.get("type")
+                if not resource_type:
+                    continue
+                interactions = {
+                    _INTERACTION_NAMES.get(item["code"], item["code"])
+                    for item in resource.get("interaction") or []
+                    if item.get("code")
+                }
+                params = {
+                    item["name"]: item.get("type", "") for item in resource.get("searchParam") or [] if item.get("name")
+                }
+                resources[resource_type] = ResourceCapability(interactions=interactions, search_params=params)
+        return cls(fhir_version=statement.get("fhirVersion"), resources=resources)
+
+
+async def fetch_capabilities(base_url: str) -> ServerCapabilities | None:
+    """One uncached fetch; None when the endpoint is absent, unreachable, or not a CapabilityStatement."""
+    url = f"{base_url.rstrip('/')}/FHIR/R5/metadata"
+    try:
+        async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT) as client:
+            response = await client.get(url)  # public endpoint: no Authorization header
+    except httpx.HTTPError as exc:
+        logger.info("Capability fetch failed for %s: %s", url, exc)
+        return None
+    if response.status_code != 200:
+        return None
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    return ServerCapabilities.from_capability_statement(body)
+
+
+async def get_capabilities(base_url: str) -> ServerCapabilities | None:
+    """TTL-cached capabilities for a JHE instance (None = unknown, cached too)."""
+    cached = _cache.get(base_url)
+    now = time.monotonic()
+    if cached is not None and now - cached[0] < CACHE_TTL_SECONDS:
+        return cached[1]
+    capabilities = await fetch_capabilities(base_url)
+    _cache[base_url] = (now, capabilities)
+    return capabilities
+
+
+def check_search_support(
+    capabilities: ServerCapabilities | None, resource_type: str, param_names: Iterable[str]
+) -> None:
+    """Raise when this instance is KNOWN not to support one of ``param_names``.
+
+    Fails open (no-op) when capabilities are None: an instance without the
+    metadata endpoint keeps today's send-and-hope behavior.
+    """
+    if capabilities is None:
+        return
+    resource = capabilities.resources.get(resource_type)
+    if resource is None:
+        raise ValueError(f"This JHE instance does not serve {resource_type} (per its CapabilityStatement).")
+    missing = sorted(set(param_names) - set(resource.search_params))
+    if missing:
+        raise ValueError(
+            f"This JHE instance does not support {resource_type} search on: {', '.join(missing)} "
+            "(per its CapabilityStatement)."
+        )
+
+
+async def preflight_observation_dates(base_url: str, start: str | None, end: str | None) -> None:
+    """Before a dated observation query: error if this instance can't filter by date."""
+    if not (start or end):
+        return
+    check_search_support(await get_capabilities(base_url), "Observation", ["date"])

--- a/mcp_server/src/jhe_mcp/tools/observation_counts.py
+++ b/mcp_server/src/jhe_mcp/tools/observation_counts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
+from jhe_mcp.fhir.capabilities import preflight_observation_dates
 from jhe_mcp.fhir.client import JheClient
 from jhe_mcp.fhir.observation_query import build_observation_params, count_observations
 from jhe_mcp.tools.study import list_study_patients
@@ -20,6 +21,7 @@ async def count_patient_observations(
     base_url: str,
 ) -> int:
     """Exact number of observations for a patient (optionally filtered)."""
+    await preflight_observation_dates(base_url, start, end)
     params = build_observation_params(patient_id=patient_id, data_type=data_type, start=start, end=end)
     async with JheClient(base_url) as client:
         return await count_observations(client, params)
@@ -35,6 +37,7 @@ async def count_study_observations(
     base_url: str,
 ) -> int | dict[str, int]:
     """Observation count for a whole study, or per-patient when by_patient=True."""
+    await preflight_observation_dates(base_url, start, end)
     if not by_patient:
         params = build_observation_params(study_id=study_id, data_type=data_type, start=start, end=end)
         async with JheClient(base_url) as client:

--- a/mcp_server/src/jhe_mcp/tools/observation_views.py
+++ b/mcp_server/src/jhe_mcp/tools/observation_views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from jhe_mcp.fhir.capabilities import preflight_observation_dates
 from jhe_mcp.fhir.client import JheClient
 from jhe_mcp.fhir.models import Observation, SlimObservation
 from jhe_mcp.fhir.observation_query import (
@@ -45,6 +46,7 @@ async def summarize_patient_observations(
     fetch server-side. ``truncated`` is True when the bounded fetch could not
     cover every record, meaning the per-type counts are lower bounds.
     """
+    await preflight_observation_dates(base_url, start, end)
     params = build_observation_params(patient_id=patient_id, start=start, end=end)
     async with JheClient(base_url) as client:
         observations, truncated = await collect_observations(client, params)
@@ -119,6 +121,7 @@ async def get_patient_observations(
     sort = _ORDER_TO_SORT.get(order)
     if sort is None:
         raise ValueError(f"order must be 'newest' or 'oldest', got {order!r}")
+    await preflight_observation_dates(base_url, start, end)
     params = build_observation_params(patient_id=patient_id, data_type=data_type, start=start, end=end)
     page_size, page = clamp_paging(limit, page)
     async with JheClient(base_url) as client:

--- a/mcp_server/src/jhe_mcp/tools/patients.py
+++ b/mcp_server/src/jhe_mcp/tools/patients.py
@@ -6,6 +6,7 @@ import re
 from datetime import date
 from typing import Any
 
+from jhe_mcp.fhir.capabilities import check_search_support, get_capabilities
 from jhe_mcp.fhir.client import JheClient
 from jhe_mcp.fhir.models import PatientSearchResult
 from jhe_mcp.fhir.paging import bundle_total, clamp_paging, page_envelope
@@ -77,6 +78,7 @@ async def search_patients(
     ``limit`` is clamped to 1..MAX_PAGE_SIZE (the server's page-size cap).
     """
     params = build_patient_params(name=name, family=family, given=given, birthdate=birthdate)
+    check_search_support(await get_capabilities(base_url), "Patient", params.keys())
     page_size, page = clamp_paging(limit, page)
     async with JheClient(base_url) as client:
         bundle = await client.fhir_get("Patient", params={**params, "_count": page_size, "_page": page})

--- a/mcp_server/tests/unit/test_capabilities.py
+++ b/mcp_server/tests/unit/test_capabilities.py
@@ -1,0 +1,134 @@
+import pytest
+import respx
+from jhe_mcp.fhir import capabilities as caps_mod
+from jhe_mcp.fhir.capabilities import (
+    ServerCapabilities,
+    check_search_support,
+    get_capabilities,
+    preflight_observation_dates,
+)
+
+
+def _statement():
+    return {
+        "resourceType": "CapabilityStatement",
+        "fhirVersion": "5.0.0",
+        "rest": [
+            {
+                "mode": "server",
+                "resource": [
+                    {
+                        "type": "Patient",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type", "extension": [{"url": "x", "valueCode": "SHALL"}]},
+                        ],
+                        "searchParam": [
+                            {"name": "birthdate", "type": "date"},
+                            {"name": "family", "type": "string"},
+                        ],
+                    },
+                    {
+                        "type": "Observation",
+                        "interaction": [{"code": "create"}],
+                        "searchParam": [{"name": "date", "type": "date"}],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    caps_mod._cache.clear()
+    yield
+    caps_mod._cache.clear()
+
+
+def test_parse_normalizes_interactions_and_ignores_extensions():
+    caps = ServerCapabilities.from_capability_statement(_statement())
+    assert caps.fhir_version == "5.0.0"
+    assert caps.resources["Patient"].interactions == {"read", "search"}
+    assert caps.resources["Patient"].search_params == {"birthdate": "date", "family": "string"}
+    assert caps.resources["Observation"].search_params == {"date": "date"}
+
+
+def test_parse_rejects_non_capability_statement():
+    assert ServerCapabilities.from_capability_statement({"resourceType": "Bundle"}) is None
+    assert ServerCapabilities.from_capability_statement("nope") is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_is_unauthenticated_and_parses():
+    route = respx.get("http://jhe/FHIR/R5/metadata").respond(200, json=_statement())
+    caps = await caps_mod.fetch_capabilities("http://jhe")
+    assert caps is not None and "Patient" in caps.resources
+    assert "authorization" not in route.calls.last.request.headers
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_absent_endpoint_yields_none():
+    respx.get("http://jhe/FHIR/R5/metadata").respond(404)
+    assert await caps_mod.fetch_capabilities("http://jhe") is None
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_caches_including_none(monkeypatch):
+    calls = []
+
+    async def fake_fetch(base_url):
+        calls.append(base_url)
+        return None
+
+    monkeypatch.setattr(caps_mod, "fetch_capabilities", fake_fetch)
+    now = {"t": 0.0}
+    monkeypatch.setattr(caps_mod.time, "monotonic", lambda: now["t"])
+    assert await get_capabilities("http://jhe") is None
+    assert await get_capabilities("http://jhe") is None
+    assert len(calls) == 1  # the miss is cached — no re-probe per tool call
+    now["t"] = caps_mod.CACHE_TTL_SECONDS + 1
+    await get_capabilities("http://jhe")
+    assert len(calls) == 2  # expired -> refetched
+
+
+def test_check_search_support_fails_open_when_unknown():
+    check_search_support(None, "Patient", ["birthdate"])  # no raise
+
+
+def test_check_search_support_passes_and_blocks():
+    caps = ServerCapabilities.from_capability_statement(_statement())
+    check_search_support(caps, "Patient", ["birthdate", "family"])  # supported -> no raise
+    with pytest.raises(ValueError, match="given"):
+        check_search_support(caps, "Patient", ["family", "given"])
+    with pytest.raises(ValueError, match="does not serve Condition"):
+        check_search_support(caps, "Condition", ["code"])
+
+
+@pytest.mark.asyncio
+async def test_preflight_observation_dates(monkeypatch):
+    async def fake_get(base_url):
+        return ServerCapabilities.from_capability_statement(_statement())
+
+    monkeypatch.setattr(caps_mod, "get_capabilities", fake_get)
+    await preflight_observation_dates("http://jhe", "2026-01-01", None)  # date supported -> ok
+
+    async def fake_get_no_date(base_url):
+        statement = _statement()
+        statement["rest"][0]["resource"][1]["searchParam"] = []
+        return ServerCapabilities.from_capability_statement(statement)
+
+    monkeypatch.setattr(caps_mod, "get_capabilities", fake_get_no_date)
+    with pytest.raises(ValueError, match="date"):
+        await preflight_observation_dates("http://jhe", "2026-01-01", None)
+
+
+@pytest.mark.asyncio
+async def test_preflight_skips_fetch_without_window(monkeypatch):
+    async def boom(base_url):
+        raise AssertionError("must not fetch when no window is given")
+
+    monkeypatch.setattr(caps_mod, "get_capabilities", boom)
+    await preflight_observation_dates("http://jhe", None, None)

--- a/mcp_server/tests/unit/test_core_registration.py
+++ b/mcp_server/tests/unit/test_core_registration.py
@@ -13,6 +13,7 @@ async def test_observation_tools_registered(monkeypatch):
     # Server instructions are sent to every client on initialize.
     assert mcp.instructions and "get_patient_date_range" in mcp.instructions
     assert "search_patients" in mcp.instructions
+    assert "get_server_capabilities" in mcp.instructions
     names = {tool.name for tool in await mcp.list_tools()}
     assert {
         "get_patient_observations",
@@ -21,4 +22,5 @@ async def test_observation_tools_registered(monkeypatch):
         "summarize_patient_observations",
         "get_patient_date_range",
         "search_patients",
+        "get_server_capabilities",
     } <= names

--- a/mcp_server/tests/unit/test_observation_counts.py
+++ b/mcp_server/tests/unit/test_observation_counts.py
@@ -26,6 +26,15 @@ def fake_client(monkeypatch):
     return client
 
 
+@pytest.fixture(autouse=True)
+def no_date_preflight(monkeypatch):
+    # Default: capabilities unknown -> date preflight is a no-op.
+    async def _noop(base_url, start, end):
+        return None
+
+    monkeypatch.setattr("jhe_mcp.tools.observation_counts.preflight_observation_dates", _noop)
+
+
 @pytest.mark.asyncio
 async def test_count_patient_observations(auth, fake_client):
     fake_client.fhir_get.return_value = {"total": 57, "entry": []}

--- a/mcp_server/tests/unit/test_observation_views.py
+++ b/mcp_server/tests/unit/test_observation_views.py
@@ -28,6 +28,15 @@ def fake_client(monkeypatch):
     return client
 
 
+@pytest.fixture(autouse=True)
+def no_date_preflight(monkeypatch):
+    # Default: capabilities unknown -> date preflight is a no-op.
+    async def _noop(base_url, start, end):
+        return None
+
+    monkeypatch.setattr("jhe_mcp.tools.observation_views.preflight_observation_dates", _noop)
+
+
 def _entry(obs_id: str, code: str, display: str, when: str, value: int) -> dict:
     payload = {
         "body": {
@@ -230,6 +239,17 @@ async def test_get_patient_date_range_empty(auth, fake_client):
     result = await get_patient_date_range(patient_id="40099", base_url="http://jhe")
     assert result == {"earliest": None, "latest": None, "count": 0}
     assert fake_client.fhir_get.await_count == 1  # zero total short-circuits the descending probe
+
+
+@pytest.mark.asyncio
+async def test_dated_query_blocked_when_instance_lacks_date_search(auth, fake_client, monkeypatch):
+    async def _block(base_url, start, end):
+        raise ValueError("This JHE instance does not support Observation search on: date")
+
+    monkeypatch.setattr("jhe_mcp.tools.observation_views.preflight_observation_dates", _block)
+    with pytest.raises(ValueError, match="date"):
+        await get_patient_observations(patient_id="40006", start="2026-04-01", base_url="http://jhe")
+    fake_client.fhir_get.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/mcp_server/tests/unit/test_tools_patients.py
+++ b/mcp_server/tests/unit/test_tools_patients.py
@@ -23,6 +23,15 @@ def fake_client(monkeypatch):
     return client
 
 
+@pytest.fixture(autouse=True)
+def unknown_capabilities(monkeypatch):
+    # Default: capabilities unknown -> preflight fails open, tools behave as before.
+    async def _none(base_url):
+        return None
+
+    monkeypatch.setattr("jhe_mcp.tools.patients.get_capabilities", _none)
+
+
 def _patient_entry(pid: str, family: str, given: str, birth: str) -> dict:
     return {
         "resource": {
@@ -135,6 +144,29 @@ async def test_search_patients_clamps_limit_and_page(auth, fake_client):
     assert result["page_size"] == 1000 and result["page"] == 1
     assert result["returned"] == 0 and result["patients"] == []
     assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_search_patients_blocks_known_unsupported_param(auth, fake_client, monkeypatch):
+    from jhe_mcp.fhir.capabilities import ServerCapabilities
+
+    caps = ServerCapabilities.from_capability_statement(
+        {
+            "resourceType": "CapabilityStatement",
+            "rest": [{"resource": [{"type": "Patient", "searchParam": [{"name": "family", "type": "string"}]}]}],
+        }
+    )
+
+    async def _caps(base_url):
+        return caps
+
+    monkeypatch.setattr("jhe_mcp.tools.patients.get_capabilities", _caps)
+    with pytest.raises(ValueError, match="birthdate"):
+        await search_patients(birthdate="1980-01-01", base_url="http://jhe")
+    fake_client.fhir_get.assert_not_awaited()
+    # A supported param still goes through.
+    fake_client.fhir_get.return_value = {"total": 0}
+    await search_patients(family="ngu", base_url="http://jhe")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #674, pairing with #676: the MCP server now consumes the JHE CapabilityStatement to understand what each instance supports.

- **`fhir/capabilities.py`** — unauthenticated fetch of `{base}/FHIR/R5/metadata` (public per FHIR; no bearer ever attached), digested to a slim per-resource `{interactions, search_params}` model, TTL-cached per base_url (300s; misses cached too, so an instance without the endpoint isn't re-probed on every call).
- **New `get_server_capabilities` tool** — returns `{available, fhir_version, resources: {type: {interactions, search_params}}}`, or `available: false` when the instance predates the metadata endpoint.
- **Preflight** — `search_patients` checks its params against Patient's declared search params, and the four date-accepting observation tools check `Observation.date`, raising a clear error when a param is *known* unsupported instead of the server silently ignoring it. **Fails open** when capabilities are unknown (older JHE, endpoint unreachable): behavior is unchanged against a pre-#676 backend.

## Testing

- 187 unit tests pass on top of merged main (parser normalization, TTL cache incl. cached misses, no-Authorization-header fetch, fail-open + blocking preflight paths, tool registration); ruff clean.

## Notes

- Depends functionally on #676 for the endpoint to exist; degrades gracefully (fail-open) without it, so merge order is flexible.
- After merge: redeploy the `jhe-mcp` app from `mcp_server/`.