### PR TITLE
docs(rfc): mark RFC 0002 Accepted (implemented in #679)

### DIFF
--- a/docs/rfcs/0002-dependency-security-unblock-uv-migration.md
+++ b/docs/rfcs/0002-dependency-security-unblock-uv-migration.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted (2026-08-04) — implemented in #679
 - **RFC issue:** #705 · **Implemented in:** #679 · **Hotfix for pre-existing main regression:** #678
 - **Process:** decided via the RFC issue (per `.github/ISSUE_TEMPLATE/02_rfc.yml`, the flow used for #334 → #391); this file is the durable design record. Accepted on maintainer approval of #679, now merged.
-- **Reviewers:** @s1monj (architecture/process), @travis-sauer-oltech (SAML behavior)
+- **Reviewers:** @travis-sauer-oltech (SAML behavior)
 - **Follows:** the provenance format piloted in RFC 0001 (#677)
 
 **TL;DR:** Three upstream pins outside our control had wedged the app so that

--- a/docs/rfcs/0002-dependency-security-unblock-uv-migration.md
+++ b/docs/rfcs/0002-dependency-security-unblock-uv-migration.md
@@ -1,8 +1,9 @@
 # RFC 0002: Unblocking dependency security updates — django-saml2-auth-community, uv, and one declared override
 
-- **Status:** Discussion
-- **Companion PR:** #679 · **Hotfix for pre-existing main regression:** #678
-- **Primary reviewers:** @s1monj (architecture/process), @travis-sauer-oltech (SAML behavior)
+- **Status:** Accepted (2026-08-04) — implemented in #679
+- **RFC issue:** #705 · **Implemented in:** #679 · **Hotfix for pre-existing main regression:** #678
+- **Process:** decided via the RFC issue (per `.github/ISSUE_TEMPLATE/02_rfc.yml`, the flow used for #334 → #391); this file is the durable design record. Accepted on maintainer approval of #679, now merged.
+- **Reviewers:** @s1monj (architecture/process), @travis-sauer-oltech (SAML behavior)
 - **Follows:** the provenance format piloted in RFC 0001 (#677)
 
 **TL;DR:** Three upstream pins outside our control had wedged the app so that


### PR DESCRIPTION
RFC 0002's design doc landed on `main` via #679 (merged 2026-08-04) but its header still read `Status: Discussion`. This flips it to **Accepted — implemented in #679** and links its RFC-flow issue #705.

Part of aligning the `docs/rfcs/` docs with the existing issue-based RFC flow (`.github/ISSUE_TEMPLATE/02_rfc.yml`, used for #334 → #391), per @travis-sauer-oltech's note on #697: the RFC **issue** is the discussion/decision venue, the `docs/rfcs/` file is the durable design record, and a doc becomes Accepted when a maintainer approves its companion PR. Companion issues: #704 (RFC 0001), #705 (RFC 0002, this doc), #706 (RFC 0003).

Docs-only, no code change.