### PR TITLE
fix(auth): verify-email resend never sent (method referenced without calling it)

### DIFF
--- a/core/views/common.py
+++ b/core/views/common.py
@@ -191,7 +191,7 @@ def signup(request):
 def verify_email(request):
     if request.method == "POST":
         if request.user.email_is_verified is not True:
-            request.user.send_email_verificaion
+            request.user.send_email_verificaion()
             return redirect("verify_email_done")
         else:
             return redirect("verify_email_complete")

--- a/tests/backend/test_verify_email_resend.py
+++ b/tests/backend/test_verify_email_resend.py
@@ -10,7 +10,9 @@ from core.models import JheUser
 
 class VerifyEmailResendTests(TestCase):
     def setUp(self):
-        self.user = JheUser.objects.create_user("unverified@example.org", password="hunter2!", user_type="practitioner")
+        self.user = JheUser.objects.create_user(
+            email="unverified@example.org", password="hunter2!", user_type="practitioner"
+        )
         self.client.force_login(self.user)
 
     def test_post_sends_verification_email(self):
@@ -18,6 +20,9 @@ class VerifyEmailResendTests(TestCase):
         self.assertRedirects(response, reverse("verify_email_done"), fetch_redirect_response=False)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [self.user.email])
+        # The email must actually carry the verification link, not just be sent —
+        # a resend with no confirm URL would leave the user unable to verify.
+        self.assertIn("/accounts/verify_email_confirm/", mail.outbox[0].body)
 
     def test_post_already_verified_sends_nothing(self):
         self.user.email_is_verified = True

--- a/tests/backend/test_verify_email_resend.py
+++ b/tests/backend/test_verify_email_resend.py
@@ -1,0 +1,27 @@
+"""The verify-email resend view must actually send the email (it redirects to
+"check your email" either way, so a silent no-op is invisible to the user)."""
+
+from django.core import mail
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import JheUser
+
+
+class VerifyEmailResendTests(TestCase):
+    def setUp(self):
+        self.user = JheUser.objects.create_user("unverified@example.org", password="hunter2!", user_type="practitioner")
+        self.client.force_login(self.user)
+
+    def test_post_sends_verification_email(self):
+        response = self.client.post(reverse("verify_email"))
+        self.assertRedirects(response, reverse("verify_email_done"), fetch_redirect_response=False)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [self.user.email])
+
+    def test_post_already_verified_sends_nothing(self):
+        self.user.email_is_verified = True
+        self.user.save(update_fields=["email_is_verified"])
+        response = self.client.post(reverse("verify_email"))
+        self.assertRedirects(response, reverse("verify_email_complete"), fetch_redirect_response=False)
+        self.assertEqual(len(mail.outbox), 0)


### PR DESCRIPTION
One-line pre-existing bug, surfaced while tracing `email_is_verified` writers for #697's review (cc @travis-sauer-oltech — the follow-up promised in [this thread](https://github.com/jupyterhealth/jupyterhealth-exchange/pull/697#discussion_r3720544565)):

`verify_email`'s POST branch read `request.user.send_email_verificaion` as a bare attribute — no call — so the resend flow redirected to "check your email" having sent nothing. The signup path calls the same method correctly, which is why first-time verification emails still went out.

Fix is the missing `()`, plus `VerifyEmailResendTests` pinning both branches: unverified user → exactly one message in the outbox to their address; already-verified user → redirect to complete, no email. (The method name's spelling — `send_email_verificaion` — is left as is to keep this minimal; happy to rename in a separate cleanup if wanted.)

981 backend tests pass; pre-commit green.