### PR TITLE
fix: require login on verify-email so anonymous POST does not 500

### DIFF
--- a/core/views/common.py
+++ b/core/views/common.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, get_user_model, login
 from django.contrib.auth import logout as django_logout
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView as BaseLoginView
 from django.http import HttpRequest, HttpResponseRedirect, JsonResponse
 from django.shortcuts import redirect, render
@@ -188,6 +189,7 @@ def signup(request):
     return render(request, "registration/signup.html", context)
 
 
+@login_required
 def verify_email(request):
     if request.method == "POST":
         if request.user.email_is_verified is not True:

--- a/tests/backend/test_verify_email.py
+++ b/tests/backend/test_verify_email.py
@@ -1,0 +1,17 @@
+"""Anonymous POST /accounts/verify_email/ must not 500 (#717)."""
+
+from django.conf import settings
+from django.urls import reverse
+
+
+def test_anonymous_verify_email_post_redirects_to_login(client):
+    response = client.post(reverse("verify_email"))
+    assert response.status_code == 302
+    assert response.url.startswith(settings.LOGIN_URL)
+    assert "next=" in response.url
+
+
+def test_anonymous_verify_email_get_redirects_to_login(client):
+    response = client.get(reverse("verify_email"))
+    assert response.status_code == 302
+    assert response.url.startswith(settings.LOGIN_URL)


### PR DESCRIPTION
## Problem

`verify_email` has no `login_required`. GET renders for anyone. POST then reads `request.user.email_is_verified`. A logged-out visitor clicking "Send Verification Email" is `AnonymousUser`, which has no such attribute, so the request 500s.

Fixes #717.

## Change

Decorate the view with `@login_required`. Anonymous GET/POST now redirect to `/accounts/login/` instead of crashing.

## Test

`tests/backend/test_verify_email.py` asserts an anonymous POST (and GET) redirect to `LOGIN_URL` rather than 500.

```
uv run pytest tests/backend/test_verify_email.py -q
# 2 passed
```
