### PR TITLE
chore: pipenv to uv cleanup

### DIFF
--- a/.github/workflows/ow-contract.yml
+++ b/.github/workflows/ow-contract.yml
@@ -65,8 +65,8 @@ jobs:
       DB_PASSWORD: postgres
       API_PORT: 8000
       OW_URL: http://localhost:8000
-      # Must match the omh-shim pin in JHE's Pipfile.
-      OMH_SHIM_VERSION: "1.0.2"
+      # Must match the omh-shim pin in JHE's pyproject.toml.
+      OMH_SHIM_VERSION: "1.4.0"
     steps:
       - name: Checkout JHE (contract harness)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/migrations_make.bash
+++ b/scripts/migrations_make.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-python manage.py makemigrations

--- a/scripts/migrations_migrate.bash
+++ b/scripts/migrations_migrate.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-python manage.py migrate

--- a/scripts/pgdump_dev.bash
+++ b/scripts/pgdump_dev.bash
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-if [ ! -f ".env" ]; then
-  printf "\nCannot find .env\n"
-  exit 2
-fi
-set -a; source .env; set +a
-PGPASSWORD="$DB_PASSWORD" pg_dump -U "$DB_USER" -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -F plain --column-inserts --data-only > dump.txt

--- a/scripts/pipenv_activate.bash
+++ b/scripts/pipenv_activate.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-pipenv shell

--- a/scripts/pipenv_path.bash
+++ b/scripts/pipenv_path.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-pipenv --venv

--- a/scripts/psql_dev.bash
+++ b/scripts/psql_dev.bash
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-if [ ! -f ".env" ]; then
-  printf "\nCannot find .env\n"
-  exit 2
-fi
-set -a; source .env; set +a
-PGPASSWORD="$DB_PASSWORD" psql -U "$DB_USER" -h "$DB_HOST" -p "$DB_PORT" "$DB_NAME"

--- a/scripts/run_precommit.bash
+++ b/scripts/run_precommit.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-pre-commit run --all-files

--- a/scripts/run_tests.bash
+++ b/scripts/run_tests.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-pytest tests/backend -v -s

--- a/scripts/seed.bash
+++ b/scripts/seed.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-python manage.py seed

--- a/scripts/start_dev.bash
+++ b/scripts/start_dev.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-python manage.py runserver


### PR DESCRIPTION
Remove the ten .bash dev helpers from scripts/. They invoked bare `python`/`pytest`, which only resolved inside an activated pipenv shell, and two of them (pipenv_activate.bash, pipenv_path.bash) wrapped pipenv commands that have no uv equivalent -- uv has no `shell` subcommand and its venv is always ./.venv. Nothing in the repo or CI referenced them. The three .py utilities in scripts/ are unaffected.

Point the OW contract harness at the omh-shim version JHE actually pins. The comment referenced a Pipfile that no longer exists, and the pin had drifted: pyproject.toml/uv.lock resolve omh-shim 1.4.0 while the harness installed 1.0.2, so the contract test was exercising a different shim than production. Verified convert() output is unchanged under 1.4.0 -- schema_id, unit, value and effective_time_frame all still satisfy tests/contract/test_ow_contract.py.