### PR TITLE
feat(seed): add seed_patient_demo for an existing patient

### DIFF
--- a/core/management/commands/seed_patient_demo.py
+++ b/core/management/commands/seed_patient_demo.py
@@ -1,0 +1,165 @@
+import random
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone as dj_timezone
+
+from core.management.commands.seed_rich_demo import (
+    CGM_CODE,
+    CGM_DATA_SOURCE,
+    CGM_INTERVAL_MINUTES,
+    CGM_SOURCE_NAME,
+    CGM_WINDOW_DAYS,
+    OMH,
+    SEED,
+    STUDY_NAME,
+    WEARABLE_DATA_SOURCE,
+    WEARABLE_MAX_DAYS,
+    WEARABLE_MIN_DAYS,
+    WEARABLE_SCOPES,
+    WEARABLE_SOURCE_NAME,
+    cgm_body,
+    cgm_value,
+    generate_wearable_day,
+    risk_score,
+)
+from core.models import (
+    CodeableConcept,
+    DataSource,
+    Observation,
+    Patient,
+    Study,
+    StudyDataSource,
+    StudyPatient,
+    StudyPatientScopeConsent,
+    StudyScopeRequest,
+)
+
+MINIMUM_PLAUSIBLE_AGE_DAYS = 365
+
+
+def required_concepts():
+    codes = [(OMH, CGM_CODE)] + [(system, code) for code, system, _label in WEARABLE_SCOPES]
+    concepts = {}
+    for system, code in codes:
+        concept = CodeableConcept.objects.filter(coding_system=system, coding_code=code).first()
+        if not concept:
+            raise CommandError(f"Missing CodeableConcept '{code}' - run `seed` first.")
+        concepts[code] = concept
+    return concepts
+
+
+def existing_demo_observations(patient):
+    return Observation.objects.filter(
+        subject_patient=patient,
+        omh_data__header__acquisition_provenance__source_name__in=[CGM_SOURCE_NAME, WEARABLE_SOURCE_NAME],
+    )
+
+
+def build_observation(patient, concept, data_source, omh_data):
+    observation = Observation(
+        subject_patient=patient,
+        codeable_concept=concept,
+        data_source=data_source,
+        status="final",
+        omh_data=omh_data,
+    )
+    observation._sync_effective_time_frame()
+    return observation
+
+
+class Command(BaseCommand):
+    help = "Attach synthetic demo data (CGM + Oura wearables) to an existing patient."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--patient-id",
+            type=int,
+            default=None,
+            help="Attach demo data to this patient, by the id field of /api/v1/patients (not jheUserId).",
+        )
+
+    def handle(self, *args, **options):
+        patient_id = options.get("patient_id")
+        if not patient_id:
+            raise CommandError("--patient-id is required.")
+
+        patient = Patient.objects.filter(pk=patient_id).first()
+        if not patient:
+            raise CommandError(f"No Patient with id {patient_id}.")
+
+        now = dj_timezone.localtime()
+        today = now.date()
+        if not patient.birth_date or (today - patient.birth_date).days < MINIMUM_PLAUSIBLE_AGE_DAYS:
+            raise CommandError(f"Patient {patient_id} has no usable birth date ({patient.birth_date}).")
+
+        organization = patient.organizations.order_by("id").first()
+        if not organization:
+            raise CommandError(f"Patient {patient_id} belongs to no Organization.")
+
+        concepts = required_concepts()
+        if existing_demo_observations(patient).exists():
+            raise CommandError(f"Patient {patient_id} already has demo data.")
+
+        cgm_source, _ = DataSource.objects.get_or_create(name=CGM_DATA_SOURCE, defaults={"type": "personal_device"})
+        wearable_source, _ = DataSource.objects.get_or_create(
+            name=WEARABLE_DATA_SOURCE, defaults={"type": "personal_device"}
+        )
+
+        rng = random.Random(f"{SEED}:{patient.id}")
+        age = (
+            today.year
+            - patient.birth_date.year
+            - ((today.month, today.day) < (patient.birth_date.month, patient.birth_date.day))
+        )
+        risk = risk_score(age)
+
+        with transaction.atomic():
+            study, _ = Study.objects.get_or_create(
+                organization=organization,
+                name=STUDY_NAME,
+                defaults={"description": "Synthetic CGM + Oura wearable demo data.", "icon_url": None},
+            )
+            StudyDataSource.objects.get_or_create(study=study, data_source=cgm_source)
+            StudyDataSource.objects.get_or_create(study=study, data_source=wearable_source)
+            study_patient, _ = StudyPatient.objects.get_or_create(study=study, patient=patient)
+            consented_time = now - timedelta(days=WEARABLE_MAX_DAYS + 3)
+            for concept in concepts.values():
+                StudyScopeRequest.objects.get_or_create(
+                    study=study, scope_code=concept, defaults={"scope_actions": "rs"}
+                )
+                StudyPatientScopeConsent.objects.update_or_create(
+                    study_patient=study_patient,
+                    scope_code=concept,
+                    defaults={"consented": True, "consented_time": consented_time, "scope_actions": "rs"},
+                )
+
+            observations = []
+            cgm_start = now - timedelta(days=CGM_WINDOW_DAYS)
+            for reading in range((CGM_WINDOW_DAYS * 24 * 60) // CGM_INTERVAL_MINUTES + 1):
+                reading_time = cgm_start + timedelta(minutes=reading * CGM_INTERVAL_MINUTES)
+                observations.append(
+                    build_observation(
+                        patient,
+                        concepts[CGM_CODE],
+                        cgm_source,
+                        cgm_body(reading_time, cgm_value(reading_time, risk, rng)),
+                    )
+                )
+
+            wearable_days = rng.randint(WEARABLE_MIN_DAYS, WEARABLE_MAX_DAYS)
+            start_day = today - timedelta(days=wearable_days - 1)
+            for offset in range(wearable_days):
+                records = generate_wearable_day(start_day + timedelta(days=offset), offset, age, risk, rng)
+                for code, _system, _label in WEARABLE_SCOPES:
+                    observations.append(build_observation(patient, concepts[code], wearable_source, records[code]))
+
+            Observation.objects.bulk_create(observations, batch_size=2000)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Patient demo seeded: patient {patient.id}, {len(observations)} observations "
+                f"in study '{study.name}' under organization '{organization.name}' (id {organization.id})."
+            )
+        )

--- a/tests/backend/test_seed_patient_demo.py
+++ b/tests/backend/test_seed_patient_demo.py
@@ -1,0 +1,162 @@
+from datetime import date
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone as dj_timezone
+
+from core.management.commands import seed_patient_demo as command
+from core.management.commands import seed_rich_demo as generator
+from core.management.commands.seed import Command as SeedCommand
+from core.models import (
+    CodeableConcept,
+    JheUser,
+    Observation,
+    Study,
+    StudyPatient,
+    StudyPatientScopeConsent,
+    StudyScopeRequest,
+)
+
+
+def create_patient(email, organization=None, birth_date=date(1970, 5, 4)):
+    user = JheUser.objects.create_user(email=email, password="unused", user_type="patient")
+    patient = user.patient_profile
+    patient.birth_date = birth_date
+    patient.save()
+    if organization:
+        patient.organizations.add(organization)
+    return patient
+
+
+def generated_codes():
+    return [generator.CGM_CODE] + [code for code, _system, _label in generator.WEARABLE_SCOPES]
+
+
+@pytest.fixture
+def demo_patient(organization, db):
+    SeedCommand.seed_codeable_concepts()
+    return create_patient("demo.patient@example.com", organization)
+
+
+@pytest.fixture
+def seeded_patient(demo_patient, monkeypatch):
+    monkeypatch.setattr(command, "CGM_WINDOW_DAYS", 1)
+    monkeypatch.setattr(command, "WEARABLE_MIN_DAYS", 2)
+    monkeypatch.setattr(command, "WEARABLE_MAX_DAYS", 2)
+    call_command("seed_patient_demo", f"--patient-id={demo_patient.id}")
+    return demo_patient
+
+
+@pytest.mark.django_db
+def test_missing_patient_id_raises():
+    with pytest.raises(CommandError, match="--patient-id"):
+        call_command("seed_patient_demo")
+
+
+@pytest.mark.django_db
+def test_unknown_patient_id_raises():
+    with pytest.raises(CommandError, match="No Patient"):
+        call_command("seed_patient_demo", "--patient-id=999999")
+
+
+@pytest.mark.django_db
+def test_patient_without_organization_raises(db):
+    SeedCommand.seed_codeable_concepts()
+    patient = create_patient("orphan.patient@example.com")
+    with pytest.raises(CommandError, match="Organization"):
+        call_command("seed_patient_demo", f"--patient-id={patient.id}")
+
+
+@pytest.mark.django_db
+def test_unusable_birth_date_raises(organization, db):
+    SeedCommand.seed_codeable_concepts()
+    patient = create_patient("newborn.patient@example.com", organization, birth_date=dj_timezone.localdate())
+    with pytest.raises(CommandError, match="birth date"):
+        call_command("seed_patient_demo", f"--patient-id={patient.id}")
+
+
+@pytest.mark.django_db
+def test_missing_codeable_concepts_raises(organization):
+    patient = create_patient("unseeded.patient@example.com", organization)
+    with pytest.raises(CommandError, match="seed"):
+        call_command("seed_patient_demo", f"--patient-id={patient.id}")
+
+
+@pytest.mark.django_db
+def test_enrolls_the_patient_with_consent_for_every_scope(seeded_patient):
+    study = Study.objects.get(name=generator.STUDY_NAME)
+    assert study.organization_id == seeded_patient.organizations.first().id
+    assert StudyPatient.objects.filter(study=study, patient=seeded_patient).exists()
+    for code in generated_codes():
+        assert StudyScopeRequest.objects.filter(study=study, scope_code__coding_code=code).exists(), code
+        assert StudyPatientScopeConsent.objects.filter(
+            study_patient__study=study,
+            study_patient__patient=seeded_patient,
+            scope_code__coding_code=code,
+            consented=True,
+        ).exists(), code
+
+
+@pytest.mark.django_db
+def test_creates_observations_for_every_scope(seeded_patient):
+    cgm = CodeableConcept.objects.get(coding_system=generator.OMH, coding_code=generator.CGM_CODE)
+    expected_cgm = (command.CGM_WINDOW_DAYS * 24 * 60) // command.CGM_INTERVAL_MINUTES + 1
+    assert Observation.objects.filter(subject_patient=seeded_patient, codeable_concept=cgm).count() == expected_cgm
+    for code, system, _label in generator.WEARABLE_SCOPES:
+        concept = CodeableConcept.objects.get(coding_system=system, coding_code=code)
+        assert Observation.objects.filter(subject_patient=seeded_patient, codeable_concept=concept).exists(), code
+
+
+@pytest.mark.django_db
+def test_observations_are_time_queryable(seeded_patient):
+    untimed = Observation.objects.filter(
+        subject_patient=seeded_patient,
+        effective_date_time__isnull=True,
+        effective_period_start__isnull=True,
+        effective_period_end__isnull=True,
+    )
+    assert untimed.count() == 0
+
+
+@pytest.mark.django_db
+def test_latest_cgm_reading_is_dated_today(seeded_patient):
+    cgm = CodeableConcept.objects.get(coding_system=generator.OMH, coding_code=generator.CGM_CODE)
+    latest = (
+        Observation.objects.filter(subject_patient=seeded_patient, codeable_concept=cgm)
+        .order_by("-omh_data__header__source_creation_date_time")
+        .first()
+    )
+    assert latest.omh_data["header"]["source_creation_date_time"][:10] == dj_timezone.localdate().isoformat()
+
+
+@pytest.mark.django_db
+def test_observations_are_visible_to_a_practitioner_under_the_study_filter(user, seeded_patient):
+    study = Study.objects.get(name=generator.STUDY_NAME)
+    visible = Observation.for_practitioner_organization_study_patient(
+        user.id,
+        study_id=study.id,
+        patient_id=seeded_patient.id,
+    )
+    assert visible.count() > 0
+
+
+@pytest.mark.django_db
+def test_second_run_refuses(seeded_patient):
+    before = Observation.objects.filter(subject_patient=seeded_patient).count()
+    with pytest.raises(CommandError):
+        call_command("seed_patient_demo", f"--patient-id={seeded_patient.id}")
+    assert Observation.objects.filter(subject_patient=seeded_patient).count() == before
+
+
+@pytest.mark.django_db
+def test_does_not_touch_other_patients(organization, demo_patient, monkeypatch):
+    monkeypatch.setattr(command, "CGM_WINDOW_DAYS", 1)
+    monkeypatch.setattr(command, "WEARABLE_MIN_DAYS", 2)
+    monkeypatch.setattr(command, "WEARABLE_MAX_DAYS", 2)
+    bystander = create_patient("bystander.patient@example.com", organization)
+
+    call_command("seed_patient_demo", f"--patient-id={demo_patient.id}")
+
+    assert Observation.objects.filter(subject_patient=bystander).count() == 0
+    assert Observation.objects.filter(subject_patient=demo_patient).count() > 0


### PR DESCRIPTION
Adds `seed_patient_demo --patient-id <id>` to give an existing patient CGM and
Oura-style demo data without rebuilding the database.

Patrick's generator moves to `core/services/demo_data.py`, shared with `seed_rich_demo`.

Fixes a bug this exposed: `bulk_create` skips `save()`, so every rich-demo observation
had NULL `effective_*` columns and was missed by FHIR `?date=` searches. Test added.

Docs: `docs/demo-data.md`.
