### PR TITLE
make git-hash development versions of image tags sortable

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # fetch all tags
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Should we push this image to a public registry?

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -103,6 +103,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # also push sortable semver jhe:1.2.3-dev35-gabcd1234 (replace + with -)
+      - name: Compute git tag
+        id: git_tag
+        run: |
+          pip install setuptools-scm
+          VERSION_TAG=$(python3 -m setuptools_scm | sed s@+@-@g)
+
+          echo "VERSION_TAG=$VERSION_TAG"
+          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
+
       # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -111,7 +121,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
-            type=sha,prefix=
+            type=raw,value=${{ env.VERSION_TAG }}
           images: ${{ env.REGISTRY }}/${{ matrix.image_name }}
 
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
for easier auto-updating of continuous publishing tools

changes opaque `085477a94` tag to `0.0.14-dev61-g085477a94`, showing it's a pre-release of 0.0.14 and 61 commits since the previous tag.