### PR TITLE
log to stderr

### DIFF
--- a/jhe/settings.py
+++ b/jhe/settings.py
@@ -238,7 +238,7 @@ LOGGING = {
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
-            "stream": "ext://sys.stdout",
+            "stream": "ext://sys.stderr",
         },
     },
     "root": {


### PR DESCRIPTION
logging to stdout conflicts with capturing output. stderr is the standard stream for logs