### PR TITLE
feat: ow_poll ingests blood glucose and follows OW pagination

### DIFF
--- a/.github/workflows/ow-contract.yml
+++ b/.github/workflows/ow-contract.yml
@@ -66,7 +66,7 @@ jobs:
       API_PORT: 8000
       OW_URL: http://localhost:8000
       # Must match the omh-shim pin in JHE's pyproject.toml.
-      OMH_SHIM_VERSION: "1.4.0"
+      OMH_SHIM_VERSION: "1.5.0"
     steps:
       - name: Checkout JHE (contract harness)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/core/management/commands/ow_poll.py
+++ b/core/management/commands/ow_poll.py
@@ -25,6 +25,16 @@ The command no-ops in two situations:
 
 OW connection config (``ow.api_url``, ``ow.api_key``) is read from JheSettings
 via ``get_setting()``, matching ``core/views/ow.py``.
+
+``OW_TYPE_TO_CODE`` maps an OW timeseries type to the CodeableConcept its
+Observations are filed under, and is intersected with the patient's consented
+scopes so a poll can never widen consent. A type only belongs there once
+omh-shim converts it to a schema id JHE can resolve: ``core/utils.py`` resolves
+the ``omh`` and ``ieee`` namespaces only, which is why ``heart_rate_variability``
+is absent (omh-shim targets ``local:heart-rate-variability:1.0``).
+
+``RAW_SUPPORTED_TYPES`` is narrower than ``OW_TYPE_TO_CODE`` because raw mode
+reads Oura API payloads, and Oura exposes no glucose.
 """
 
 import logging
@@ -52,10 +62,23 @@ logger = logging.getLogger(__name__)
 
 POLL_OVERLAP = timedelta(minutes=5)
 POLL_WINDOW = timedelta(days=1)
+PAGE_LIMIT = 100
+MAX_PAGES = 200
 HEART_RATE_CODE = "omh:heart-rate:2.0"
+BLOOD_GLUCOSE_CODE = "omh:blood-glucose:4.0"
+
+OW_TYPE_TO_CODE = {
+    "heart_rate": HEART_RATE_CODE,
+    "blood_glucose": BLOOD_GLUCOSE_CODE,
+}
+OW_TYPE_TO_DATA_SOURCE = {
+    "heart_rate": "Oura",
+    "blood_glucose": "Dexcom",
+}
 NORMALIZED_SYSTEM = "ow:normalized"
 RAW_SYSTEM = "ow:raw"
 RAW_TRACE_ID_HEART_RATE = "/v2/usercollection/heartrate"
+RAW_SUPPORTED_TYPES = {"heart_rate"}
 _SYNC_LOCK_KEY = "ow.sync_in_progress"
 # A lock older than this is considered abandoned (worker crashed mid-poll)
 # and is force-reclaimed by the next tick. Sized at ~2x the default cron
@@ -150,13 +173,19 @@ class Command(BaseCommand):
             self.stderr.write("ow_poll aborted: ow.api_url / ow.api_key not configured")
             return
 
-        try:
-            hr_code = CodeableConcept.objects.get(coding_code=HEART_RATE_CODE)
-        except CodeableConcept.DoesNotExist:
-            self.stderr.write(f"CodeableConcept '{HEART_RATE_CODE}' not found. Run seed first.")
+        codes = {}
+        for ow_type, coding_code in OW_TYPE_TO_CODE.items():
+            try:
+                codes[ow_type] = CodeableConcept.objects.get(coding_code=coding_code)
+            except CodeableConcept.DoesNotExist:
+                self.stderr.write(f"CodeableConcept '{coding_code}' not found. Run seed first.")
+        if not codes:
             return
 
-        oura_ds, _ = DataSource.objects.get_or_create(name="Oura", defaults={"type": "personal_device"})
+        data_sources = {
+            ow_type: DataSource.objects.get_or_create(name=name, defaults={"type": "personal_device"})[0]
+            for ow_type, name in OW_TYPE_TO_DATA_SOURCE.items()
+        }
 
         # Only users linked to an OW account: identifier startswith "ow:".
         users = JheUser.objects.filter(identifier__startswith="ow:")
@@ -170,21 +199,73 @@ class Command(BaseCommand):
             if patient is None:
                 continue
             consented_codes = {s.coding_code for s in patient.consolidated_consented_scopes()}
-            if HEART_RATE_CODE not in consented_codes:
+            polled = {t: c for t, c in codes.items() if c.coding_code in consented_codes}
+            if not polled:
                 continue
 
-            try:
-                if mode == "normalized":
-                    created = self._poll_user_normalized(user, patient, oura_ds, hr_code, ow_api_url, ow_api_key)
-                else:
-                    created = self._poll_user_raw(user, patient, oura_ds, hr_code)
-                total_created += created
-            except Exception:
-                logger.exception("ow_poll failed for jhe_user_id=%s", user.id)
+            for ow_type, code in polled.items():
+                try:
+                    if mode == "normalized":
+                        created = self._poll_user_normalized(
+                            user, patient, ow_type, code, data_sources[ow_type], ow_api_url, ow_api_key
+                        )
+                    else:
+                        created = self._poll_user_raw(user, patient, ow_type, code, data_sources[ow_type])
+                    total_created += created
+                except Exception:
+                    logger.exception("ow_poll failed for jhe_user_id=%s type=%s", user.id, ow_type)
 
         self.stdout.write(self.style.SUCCESS(f"OW poll complete (mode={mode}). Created {total_created} observations."))
 
-    def _poll_user_normalized(self, user, patient, data_source, hr_code, ow_api_url, ow_api_key):
+    def _fetch_timeseries(self, user, ow_api_url, ow_api_key, ow_user_id, data_type, start_time, end_time):
+        """Yield every OW sample across pages. OW caps a page at PAGE_LIMIT and returns a cursor."""
+        cursor = None
+        for _ in range(MAX_PAGES):
+            params = {
+                "types": data_type,
+                "start_time": start_time.isoformat(),
+                "end_time": end_time.isoformat(),
+                "limit": PAGE_LIMIT,
+            }
+            if cursor:
+                params["cursor"] = cursor
+
+            try:
+                resp = requests.get(
+                    f"{ow_api_url}/api/v1/users/{ow_user_id}/timeseries",
+                    params=params,
+                    headers={"X-Open-Wearables-API-Key": ow_api_key},
+                    timeout=30,
+                )
+            except requests.RequestException as e:
+                logger.error("OW timeseries request failed for user=%s: %s", user.id, e)
+                return
+
+            if resp.status_code != 200:
+                logger.error(
+                    "OW timeseries error for user=%s: %s %s",
+                    user.id,
+                    resp.status_code,
+                    resp.text[:300],
+                )
+                return
+
+            data = resp.json()
+            records = data.get("data", data) if isinstance(data, dict) else data
+            if not isinstance(records, list):
+                logger.warning("OW timeseries returned non-list payload for user=%s", user.id)
+                return
+            yield from records
+
+            pagination = data.get("pagination") or {} if isinstance(data, dict) else {}
+            next_cursor = pagination.get("next_cursor")
+            if not pagination.get("has_more") or not next_cursor or next_cursor == cursor:
+                return
+            cursor = next_cursor
+
+        logger.warning("OW timeseries hit MAX_PAGES for user=%s type=%s", user.id, data_type)
+
+    def _poll_user_normalized(self, user, patient, ow_type, code, data_source, ow_api_url, ow_api_key):
         ow_user_id = user.identifier.removeprefix("ow:")
         end_time = timezone.now()
         start_time = end_time - POLL_WINDOW
@@ -194,7 +275,7 @@ class Command(BaseCommand):
         last_obs = (
             Observation.objects.filter(
                 subject_patient=patient,
-                codeable_concept=hr_code,
+                codeable_concept=code,
                 identifiers__system=NORMALIZED_SYSTEM,
             )
             .order_by("-last_updated")
@@ -203,40 +284,12 @@ class Command(BaseCommand):
         if last_obs:
             start_time = max(start_time, last_obs.last_updated - POLL_OVERLAP)
 
-        try:
-            resp = requests.get(
-                f"{ow_api_url}/api/v1/users/{ow_user_id}/timeseries",
-                params={
-                    "types": "heart_rate",
-                    "start_time": start_time.isoformat(),
-                    "end_time": end_time.isoformat(),
-                },
-                headers={"X-Open-Wearables-API-Key": ow_api_key},
-                timeout=30,
-            )
-        except requests.RequestException as e:
-            logger.error("OW timeseries request failed for user=%s: %s", user.id, e)
-            return 0
-
-        if resp.status_code != 200:
-            logger.error(
-                "OW timeseries error for user=%s: %s %s",
-                user.id,
-                resp.status_code,
-                resp.text[:300],
-            )
-            return 0
-
-        data = resp.json()
-        records = data.get("data", data) if isinstance(data, dict) else data
-        if not isinstance(records, list):
-            logger.warning("OW timeseries returned non-list payload for user=%s", user.id)
-            return 0
+        records = self._fetch_timeseries(user, ow_api_url, ow_api_key, ow_user_id, ow_type, start_time, end_time)
 
         created = 0
         for record in records:
             try:
-                omh_record = convert(source="ow_normalized", data_type="heart_rate", sample=record)
+                omh_record = convert(source="ow_normalized", data_type=ow_type, sample=record)
             except Exception:
                 logger.warning("Skipping unconvertible record for user=%s", user.id, exc_info=True)
                 continue
@@ -253,7 +306,7 @@ class Command(BaseCommand):
                 with transaction.atomic():
                     obs = Observation.objects.create(
                         subject_patient=patient,
-                        codeable_concept=hr_code,
+                        codeable_concept=code,
                         data_source=data_source,
                         omh_data=omh_record,
                         status="final",
@@ -278,7 +331,7 @@ class Command(BaseCommand):
         logger.info("Poll completed for jhe_user=%s patient=%s created=%d", user.id, patient.id, created)
         return created
 
-    def _poll_user_raw(self, user, patient, data_source, hr_code):
+    def _poll_user_raw(self, user, patient, ow_type, code, data_source):
         """Raw S3-backed ingest. Walks the OW MinIO bucket for new objects.
 
         Each individual record (not each S3 object) is deduped via
@@ -286,6 +339,9 @@ class Command(BaseCommand):
         mirroring the normalized path so that idempotency is guaranteed even
         if the same payload is re-uploaded under a different S3 key.
         """
+        if ow_type not in RAW_SUPPORTED_TYPES:
+            return 0
+
         ow_user_id = user.identifier.removeprefix("ow:")
         end_time = timezone.now()
         start_time = end_time - POLL_WINDOW
@@ -293,7 +349,7 @@ class Command(BaseCommand):
         last_obs = (
             Observation.objects.filter(
                 subject_patient=patient,
-                codeable_concept=hr_code,
+                codeable_concept=code,
                 identifiers__system=RAW_SYSTEM,
             )
             .order_by("-last_updated")
@@ -322,7 +378,7 @@ class Command(BaseCommand):
 
             for record in payload.get("data", []):
                 try:
-                    omh_record = convert(source="oura_raw", data_type="heart_rate", sample=record)
+                    omh_record = convert(source="oura_raw", data_type=ow_type, sample=record)
                 except Exception:
                     logger.warning("Skipping unconvertible raw record key=%s", obj.key, exc_info=True)
                     continue
@@ -338,7 +394,7 @@ class Command(BaseCommand):
                     with transaction.atomic():
                         obs = Observation.objects.create(
                             subject_patient=patient,
-                            codeable_concept=hr_code,
+                            codeable_concept=code,
                             data_source=data_source,
                             omh_data=omh_record,
                             status="final",

--- a/core/management/commands/ow_poll.py
+++ b/core/management/commands/ow_poll.py
@@ -71,10 +71,6 @@ OW_TYPE_TO_CODE = {
     "heart_rate": HEART_RATE_CODE,
     "blood_glucose": BLOOD_GLUCOSE_CODE,
 }
-OW_TYPE_TO_DATA_SOURCE = {
-    "heart_rate": "Oura",
-    "blood_glucose": "Dexcom",
-}
 NORMALIZED_SYSTEM = "ow:normalized"
 RAW_SYSTEM = "ow:raw"
 RAW_TRACE_ID_HEART_RATE = "/v2/usercollection/heartrate"
@@ -182,10 +178,7 @@ class Command(BaseCommand):
         if not codes:
             return
 
-        data_sources = {
-            ow_type: DataSource.objects.get_or_create(name=name, defaults={"type": "personal_device"})[0]
-            for ow_type, name in OW_TYPE_TO_DATA_SOURCE.items()
-        }
+        oura_ds, _ = DataSource.objects.get_or_create(name="Oura", defaults={"type": "personal_device"})
 
         # Only users linked to an OW account: identifier startswith "ow:".
         users = JheUser.objects.filter(identifier__startswith="ow:")
@@ -207,10 +200,10 @@ class Command(BaseCommand):
                 try:
                     if mode == "normalized":
                         created = self._poll_user_normalized(
-                            user, patient, ow_type, code, data_sources[ow_type], ow_api_url, ow_api_key
+                            user, patient, ow_type, code, oura_ds, ow_api_url, ow_api_key
                         )
                     else:
-                        created = self._poll_user_raw(user, patient, ow_type, code, data_sources[ow_type])
+                        created = self._poll_user_raw(user, patient, ow_type, code, oura_ds)
                     total_created += created
                 except Exception:
                     logger.exception("ow_poll failed for jhe_user_id=%s type=%s", user.id, ow_type)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "jsonschema",
     "ipython",
     "boto3",
-    "omh-shim==1.4.0",
+    "omh-shim==1.5.0",
 ]
 
 [dependency-groups]

--- a/tests/backend/test_ow_poll.py
+++ b/tests/backend/test_ow_poll.py
@@ -3,7 +3,7 @@ Tests for the `ow_poll` management command (normalized + raw modes).
 """
 
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
@@ -312,3 +312,127 @@ def test_stale_lock_is_force_released(db, ow_user, patient_with_consent, hr_conc
     # Force-reclaim: poll ran, observation persisted, lock cleared on exit.
     assert Observation.objects.count() == 1
     assert not get_setting("ow.sync_in_progress")
+
+
+def test_normalized_mode_follows_pagination(db, ow_user, patient_with_consent, hr_concept):
+    """OW caps a page at 50 samples and returns a cursor; every page must be fetched."""
+    _set_jhe_setting("module.ow", True)
+    _clear_sync_lock()
+
+    page_1 = {
+        "data": [{"timestamp": "2024-01-01T00:00:00Z", "value": 72}],
+        "pagination": {"next_cursor": "cursor-2", "has_more": True},
+    }
+    page_2 = {
+        "data": [{"timestamp": "2024-01-01T00:01:00Z", "value": 73}],
+        "pagination": {"next_cursor": None, "has_more": False},
+    }
+
+    with (
+        patch("core.management.commands.ow_poll.requests.get") as mock_get,
+        patch("core.management.commands.ow_poll.convert") as mock_convert,
+    ):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.side_effect = [page_1, page_2]
+        mock_convert.side_effect = [_fake_omh_record("p1"), _fake_omh_record("p2")]
+
+        call_command("ow_poll", stdout=StringIO())
+
+    assert mock_get.call_count == 2, "second page was never requested"
+    assert mock_get.call_args_list[1].kwargs["params"]["cursor"] == "cursor-2"
+
+
+def test_ingests_blood_glucose_when_consented(db, ow_user, patient_with_consent):
+    """Glucose reaches OW through the mobile SDK, so the poller must ask for it too."""
+    from core.models import StudyPatient, StudyPatientScopeConsent, StudyScopeRequest
+
+    bg = CodeableConcept.objects.create(
+        coding_system="https://w3id.org/openmhealth",
+        coding_code="omh:blood-glucose:4.0",
+        text="Blood glucose",
+    )
+    sp = StudyPatient.objects.filter(patient=patient_with_consent).first()
+    StudyScopeRequest.objects.create(study=sp.study, scope_code=bg)
+    StudyPatientScopeConsent.objects.create(
+        study_patient=sp, scope_code=bg, consented=True, consented_time=timezone.now()
+    )
+
+    sample = {
+        "timestamp": "2026-08-31T08:00:00Z",
+        "type": "blood_glucose",
+        "value": 110,
+        "unit": "mg_dl",
+        "source": {"provider": "Stelo", "device": None},
+    }
+
+    _set_jhe_setting("module.ow", True)
+    _clear_sync_lock()
+
+    def _by_type(*args, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        wanted = kwargs["params"]["types"]
+        resp.json.return_value = {
+            "data": [sample] if wanted == "blood_glucose" else [],
+            "pagination": {"next_cursor": None, "has_more": False},
+        }
+        return resp
+
+    with patch("core.management.commands.ow_poll.requests.get", side_effect=_by_type):
+        call_command("ow_poll", stdout=StringIO())
+
+    obs = Observation.objects.filter(subject_patient=patient_with_consent, codeable_concept=bg)
+    assert obs.count() == 1
+    assert obs.first().omh_data["body"]["blood_glucose"] == {"value": 110.0, "unit": "mg/dL"}
+    assert obs.first().data_source.name == "Dexcom"
+    assert not Observation.objects.filter(
+        subject_patient=patient_with_consent, codeable_concept__coding_code=HR_CODE
+    ).exists(), "glucose sample must not be converted as heart rate"
+
+
+def test_raw_mode_skips_types_with_no_oura_converter(db, ow_user, patient_with_consent):
+    """Oura exposes no glucose, so raw mode must not walk S3 for it."""
+    from core.models import StudyPatient, StudyPatientScopeConsent, StudyScopeRequest
+
+    bg = CodeableConcept.objects.create(
+        coding_system="https://w3id.org/openmhealth",
+        coding_code="omh:blood-glucose:4.0",
+        text="Blood glucose",
+    )
+    sp = StudyPatient.objects.filter(patient=patient_with_consent).first()
+    StudyScopeRequest.objects.create(study=sp.study, scope_code=bg)
+    StudyPatientScopeConsent.objects.create(
+        study_patient=sp, scope_code=bg, consented=True, consented_time=timezone.now()
+    )
+
+    _set_jhe_setting("module.ow", True)
+    _set_jhe_setting("ow.ingest_mode", "raw", value_type="string")
+    _clear_sync_lock()
+
+    with patch("core.management.commands.ow_poll.list_new_objects") as mock_list:
+        mock_list.return_value = []
+        call_command("ow_poll", stdout=StringIO())
+
+    called_types = [c for c in mock_list.call_args_list]
+    assert len(called_types) == 1, "raw mode should only walk S3 for heart_rate"
+
+
+def test_raw_mode_handles_string_source_field(db, ow_user, patient_with_consent, hr_concept):
+    """Oura raw records carry source as a string ("awake"), not an object."""
+    _set_jhe_setting("module.ow", True)
+    _set_jhe_setting("ow.ingest_mode", "raw", value_type="string")
+    _clear_sync_lock()
+
+    obj = type("Obj", (), {"key": "/v2/usercollection/heartrate/x.json", "last_modified": timezone.now()})()
+
+    with (
+        patch("core.management.commands.ow_poll.list_new_objects") as mock_list,
+        patch("core.management.commands.ow_poll.read_object") as mock_read,
+        patch("core.management.commands.ow_poll.convert") as mock_convert,
+    ):
+        mock_list.return_value = [obj]
+        mock_read.return_value = {"data": [{"bpm": 72, "source": "awake", "timestamp": "2026-01-01T00:00:00+00:00"}]}
+        mock_convert.return_value = _fake_omh_record("raw-str-1")
+        call_command("ow_poll", stdout=StringIO())
+
+    assert Observation.objects.filter(subject_patient=patient_with_consent).count() == 1

--- a/tests/backend/test_ow_poll.py
+++ b/tests/backend/test_ow_poll.py
@@ -384,7 +384,6 @@ def test_ingests_blood_glucose_when_consented(db, ow_user, patient_with_consent)
     obs = Observation.objects.filter(subject_patient=patient_with_consent, codeable_concept=bg)
     assert obs.count() == 1
     assert obs.first().omh_data["body"]["blood_glucose"] == {"value": 110.0, "unit": "mg/dL"}
-    assert obs.first().data_source.name == "Dexcom"
     assert not Observation.objects.filter(
         subject_patient=patient_with_consent, codeable_concept__coding_code=HR_CODE
     ).exists(), "glucose sample must not be converted as heart rate"

--- a/uv.lock
+++ b/uv.lock
@@ -758,7 +758,7 @@ requires-dist = [
     { name = "gunicorn" },
     { name = "ipython" },
     { name = "jsonschema" },
-    { name = "omh-shim", specifier = "==1.4.0" },
+    { name = "omh-shim", specifier = "==1.5.0" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pyhumps" },
@@ -927,15 +927,15 @@ wheels = [
 
 [[package]]
 name = "omh-shim"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/ab/438e8cf2f9cd188c25d1c6bf48fbd2bf8ad25badcc3f37fbcfe04a42941f/omh_shim-1.4.0.tar.gz", hash = "sha256:77e857b1d82881605de74bcf0e33ab1c25cd9a7caee63db6a648ff2dd1f5c419", size = 38735, upload-time = "2026-06-21T10:07:37.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/e5/6a2f1f8251ed836a41af6438efad3e5c180bdd4fa976b16a80923e96df76/omh_shim-1.5.0.tar.gz", hash = "sha256:aa0af84bab5d489421127536e7144212d28e54e034d7a45e1a9050f1bef9c755", size = 38904, upload-time = "2026-08-31T18:45:39.826Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/97/f2d55355bac927a35c6e8f7d91f35505c4371e96326e74af4665fbdfad2d/omh_shim-1.4.0-py3-none-any.whl", hash = "sha256:45815d5ad840b58adb35e84f067430e0046c92f4718f16661e53d84fd916a75e", size = 58083, upload-time = "2026-06-21T10:07:36.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/1c76ccecef5dd27c60595b5ba70e87b29c210bfca16c3baf38d3d40bb97d/omh_shim-1.5.0-py3-none-any.whl", hash = "sha256:66fc3e4cc6ad088ac7888a14704da801aabb58689d6f8994197a9b4ae5696a5d", size = 58260, upload-time = "2026-08-31T18:45:38.649Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Polls blood glucose in addition to heart rate, driven by the patient's consented scopes. Also follows OW's pagination cursor, which was capping each run at 50 samples.

Needs omh-shim 1.5.0.