### PR TITLE
feat: run ow_poll on a schedule via a cron process group

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,3 @@
-
-
 app = "jhe"
 primary_region = "ewr"
 console_command = "/code/manage.py shell"
@@ -9,6 +7,10 @@ console_command = "/code/manage.py shell"
 
 [deploy]
   release_command = "python manage.py migrate --noinput"
+
+[processes]
+  app = "gunicorn --bind :8000 --workers 2 jhe.wsgi"
+  cron = "supercronic /code/deploy/crontab"
 
 [env]
   PORT = "8000"
@@ -22,11 +24,19 @@ console_command = "/code/manage.py shell"
   auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 1
+  processes = ["app"]
 
 [[vm]]
   memory = "1gb"
   cpu_kind = "shared"
   cpus = 1
+  processes = ["app"]
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1
+  processes = ["cron"]
 
 [[http_service.checks]]
   grace_period = "30s"


### PR DESCRIPTION
fly.toml had no processes block, so only gunicorn ran and ow_poll never fired. deploy/crontab and supercronic were already in the image, just never launched.

Adds a cron process group. Same pattern as ow-poc.