### PR TITLE
feat: return an OW SDK token from POST /api/v1/ow/users

### DIFF
--- a/core/views/ow.py
+++ b/core/views/ow.py
@@ -22,6 +22,41 @@ from core.services.jhe_settings import get_setting
 logger = logging.getLogger(__name__)
 
 
+def _sdk_token(ow_api_url, ow_user_id):
+    """Exchange the Application credentials for a token scoped to one OW user.
+
+    Open Wearables rejects a JHE token on its SDK endpoints, and its API key is
+    tenant-wide, so the mobile app is given a short-lived user-scoped token
+    instead. The credentials stay here; the app refreshes against OW directly.
+    """
+    app_id = get_setting("ow.app_id", "")
+    app_secret = get_setting("ow.app_secret", "")
+    if not app_id or not app_secret:
+        logger.warning("ow.app_id / ow.app_secret not configured; returning no SDK token")
+        return {}
+
+    try:
+        response = requests.post(
+            f"{ow_api_url}/api/v1/users/{ow_user_id}/token",
+            json={"app_id": app_id, "app_secret": app_secret},
+            timeout=10,
+        )
+    except requests.RequestException as e:
+        logger.error("Failed to mint OW SDK token for %s: %s", ow_user_id, e)
+        return {}
+
+    if response.status_code != 200:
+        logger.error("OW token error for %s: %s %s", ow_user_id, response.status_code, response.text[:300])
+        return {}
+
+    token = response.json()
+    return {
+        "access_token": token.get("access_token"),
+        "refresh_token": token.get("refresh_token"),
+        "expires_in": token.get("expires_in"),
+    }
+
+
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def create_ow_user(request):
@@ -41,7 +76,8 @@ def create_ow_user(request):
     # Check if user already has an OW user_id stored. The identifier field can also
     # hold non-OW identifiers (e.g. FHIR refs from seed data), so match the prefix.
     if user.identifier and user.identifier.startswith("ow:"):
-        return Response({"ow_user_id": user.identifier.removeprefix("ow:")})
+        ow_user_id = user.identifier.removeprefix("ow:")
+        return Response({"ow_user_id": ow_user_id, **_sdk_token(ow_api_url, ow_user_id)})
 
     # Create user in OW
     payload = {
@@ -74,7 +110,7 @@ def create_ow_user(request):
     user.identifier = f"ow:{ow_user_id}"
     user.save(update_fields=["identifier"])
 
-    return Response({"ow_user_id": ow_user_id})
+    return Response({"ow_user_id": ow_user_id, **_sdk_token(ow_api_url, ow_user_id)})
 
 
 @api_view(["GET"])

--- a/tests/backend/test_ow_integration.py
+++ b/tests/backend/test_ow_integration.py
@@ -87,6 +87,13 @@ def ow_settings(db):
 
 
 @pytest.fixture
+def ow_app_settings(db):
+    """Application credentials used to mint user-scoped SDK tokens."""
+    _set_ow_setting("ow.app_id", "app_testappid")
+    _set_ow_setting("ow.app_secret", "secret_testappsecret")
+
+
+@pytest.fixture
 def no_ow_settings(db):
     """Force OW config off regardless of the host environment."""
     _set_ow_setting("ow.api_url", "")
@@ -138,6 +145,45 @@ class TestCreateOwUser:
         assert resp.status_code == 200
         data = resp.json()
         assert data["owUserId"] == "550e8400-e29b-41d4-a716-446655440000"
+
+    @patch("core.views.ow.requests.post")
+    def test_returns_sdk_token_for_new_user(self, mock_post, ow_client, ow_user, ow_settings, ow_app_settings):
+        """The Flutter SDK needs an OW token with scope=sdk; a JHE token is rejected by OW."""
+        create_resp = MagicMock(status_code=201)
+        create_resp.json.return_value = {"id": "new-ow-user-id-123"}
+        token_resp = MagicMock(status_code=200)
+        token_resp.json.return_value = {
+            "access_token": "ow-access-token",
+            "refresh_token": "ow-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 3600,
+        }
+        mock_post.side_effect = [create_resp, token_resp]
+
+        data = ow_client.post(self.URL).json()
+
+        assert data["owUserId"] == "new-ow-user-id-123"
+        assert data["accessToken"] == "ow-access-token"
+        assert data["refreshToken"] == "ow-refresh-token"
+
+        token_call = mock_post.call_args_list[1]
+        assert token_call[0][0].endswith("/api/v1/users/new-ow-user-id-123/token")
+        assert token_call[1]["json"] == {"app_id": "app_testappid", "app_secret": "secret_testappsecret"}
+
+    @patch("core.views.ow.requests.post")
+    def test_returns_fresh_token_for_already_linked_user(
+        self, mock_post, ow_linked_client, ow_user_with_id, ow_settings, ow_app_settings
+    ):
+        """SDK tokens expire after an hour, so a returning user must still get one."""
+        token_resp = MagicMock(status_code=200)
+        token_resp.json.return_value = {"access_token": "fresh-token", "refresh_token": "fresh-refresh"}
+        mock_post.return_value = token_resp
+
+        data = ow_linked_client.post(self.URL).json()
+
+        assert data["owUserId"] == "550e8400-e29b-41d4-a716-446655440000"
+        assert data["accessToken"] == "fresh-token"
+        mock_post.assert_called_once()
 
     @patch("core.views.ow.requests.post")
     def test_passes_through_409_conflict(self, mock_post, ow_client, ow_user, ow_settings):


### PR DESCRIPTION
Returns a user-scoped OW token so the mobile SDK can authenticate. Needs ow.app_id and ow.app_secret.