### PR TITLE
feat: make OW SDK tokens opt-in and prefix the response keys

### DIFF
--- a/core/views/ow.py
+++ b/core/views/ow.py
@@ -27,7 +27,9 @@ def _sdk_token(ow_api_url, ow_user_id):
 
     Open Wearables rejects a JHE token on its SDK endpoints, and its API key is
     tenant-wide, so the mobile app is given a short-lived user-scoped token
-    instead. The credentials stay here; the app refreshes against OW directly.
+    instead. The credentials stay here; the app refreshes against OW directly at
+    the returned endpoint. Callers that only need the linked id, such as the
+    browser client, should leave ``include_ow_tokens`` unset.
     """
     app_id = get_setting("ow.app_id", "")
     app_secret = get_setting("ow.app_secret", "")
@@ -51,9 +53,10 @@ def _sdk_token(ow_api_url, ow_user_id):
 
     token = response.json()
     return {
-        "access_token": token.get("access_token"),
-        "refresh_token": token.get("refresh_token"),
-        "expires_in": token.get("expires_in"),
+        "ow_access_token": token.get("access_token"),
+        "ow_refresh_token": token.get("refresh_token"),
+        "ow_expires_in": token.get("expires_in"),
+        "ow_token_endpoint": f"{ow_api_url}/api/v1/token/refresh",
     }
 
 
@@ -75,9 +78,12 @@ def create_ow_user(request):
 
     # Check if user already has an OW user_id stored. The identifier field can also
     # hold non-OW identifiers (e.g. FHIR refs from seed data), so match the prefix.
+    include_tokens = bool(request.data.get("include_ow_tokens"))
+
     if user.identifier and user.identifier.startswith("ow:"):
         ow_user_id = user.identifier.removeprefix("ow:")
-        return Response({"ow_user_id": ow_user_id, **_sdk_token(ow_api_url, ow_user_id)})
+        tokens = _sdk_token(ow_api_url, ow_user_id) if include_tokens else {}
+        return Response({"ow_user_id": ow_user_id, **tokens})
 
     # Create user in OW
     payload = {
@@ -110,7 +116,8 @@ def create_ow_user(request):
     user.identifier = f"ow:{ow_user_id}"
     user.save(update_fields=["identifier"])
 
-    return Response({"ow_user_id": ow_user_id, **_sdk_token(ow_api_url, ow_user_id)})
+    tokens = _sdk_token(ow_api_url, ow_user_id) if include_tokens else {}
+    return Response({"ow_user_id": ow_user_id, **tokens})
 
 
 @api_view(["GET"])

--- a/tests/backend/test_ow_integration.py
+++ b/tests/backend/test_ow_integration.py
@@ -147,7 +147,7 @@ class TestCreateOwUser:
         assert data["owUserId"] == "550e8400-e29b-41d4-a716-446655440000"
 
     @patch("core.views.ow.requests.post")
-    def test_returns_sdk_token_for_new_user(self, mock_post, ow_client, ow_user, ow_settings, ow_app_settings):
+    def test_returns_sdk_token_when_requested(self, mock_post, ow_client, ow_user, ow_settings, ow_app_settings):
         """The Flutter SDK needs an OW token with scope=sdk; a JHE token is rejected by OW."""
         create_resp = MagicMock(status_code=201)
         create_resp.json.return_value = {"id": "new-ow-user-id-123"}
@@ -160,15 +160,29 @@ class TestCreateOwUser:
         }
         mock_post.side_effect = [create_resp, token_resp]
 
-        data = ow_client.post(self.URL).json()
+        data = ow_client.post(self.URL, {"include_ow_tokens": True}, format="json").json()
 
         assert data["owUserId"] == "new-ow-user-id-123"
-        assert data["accessToken"] == "ow-access-token"
-        assert data["refreshToken"] == "ow-refresh-token"
+        assert data["owAccessToken"] == "ow-access-token"
+        assert data["owRefreshToken"] == "ow-refresh-token"
+        assert data["owExpiresIn"] == 3600
+        assert data["owTokenEndpoint"] == "https://ow.example.com/api/v1/token/refresh"
 
         token_call = mock_post.call_args_list[1]
         assert token_call[0][0].endswith("/api/v1/users/new-ow-user-id-123/token")
         assert token_call[1]["json"] == {"app_id": "app_testappid", "app_secret": "secret_testappsecret"}
+
+    @patch("core.views.ow.requests.post")
+    def test_omits_sdk_token_by_default(self, mock_post, ow_client, ow_user, ow_settings, ow_app_settings):
+        """The browser client calls this endpoint too and must not receive an OW credential."""
+        create_resp = MagicMock(status_code=201)
+        create_resp.json.return_value = {"id": "new-ow-user-id-123"}
+        mock_post.return_value = create_resp
+
+        data = ow_client.post(self.URL).json()
+
+        assert data == {"owUserId": "new-ow-user-id-123"}
+        mock_post.assert_called_once()
 
     @patch("core.views.ow.requests.post")
     def test_returns_fresh_token_for_already_linked_user(
@@ -179,10 +193,10 @@ class TestCreateOwUser:
         token_resp.json.return_value = {"access_token": "fresh-token", "refresh_token": "fresh-refresh"}
         mock_post.return_value = token_resp
 
-        data = ow_linked_client.post(self.URL).json()
+        data = ow_linked_client.post(self.URL, {"include_ow_tokens": True}, format="json").json()
 
         assert data["owUserId"] == "550e8400-e29b-41d4-a716-446655440000"
-        assert data["accessToken"] == "fresh-token"
+        assert data["owAccessToken"] == "fresh-token"
         mock_post.assert_called_once()
 
     @patch("core.views.ow.requests.post")


### PR DESCRIPTION
POST /api/v1/ow/users only mints an OW token when include_ow_tokens is set, and the token fields are now prefixed with ow_ and include the refresh endpoint.