### PR TITLE
feat: make the OW poll window configurable

### DIFF
--- a/core/management/commands/ow_poll.py
+++ b/core/management/commands/ow_poll.py
@@ -35,6 +35,12 @@ is absent (omh-shim targets ``local:heart-rate-variability:1.0``).
 
 ``RAW_SUPPORTED_TYPES`` is narrower than ``OW_TYPE_TO_CODE`` because raw mode
 reads Oura API payloads, and Oura exposes no glucose.
+
+``ow.poll_window_days`` (default 1) sets how far back OW is asked for samples.
+It only bounds a patient's first poll: once they have an Observation the resume
+watermark is the later bound, so a wide window costs nothing afterwards. Raise
+it when patients link with device history already recorded, or pass ``--days``
+for a one-off backfill.
 """
 
 import logging
@@ -61,7 +67,7 @@ from core.services.ow_ingest import list_new_objects, read_object
 logger = logging.getLogger(__name__)
 
 POLL_OVERLAP = timedelta(minutes=5)
-POLL_WINDOW = timedelta(days=1)
+DEFAULT_POLL_WINDOW_DAYS = 1
 PAGE_LIMIT = 100
 MAX_PAGES = 200
 HEART_RATE_CODE = "omh:heart-rate:2.0"
@@ -103,6 +109,12 @@ class Command(BaseCommand):
             type=int,
             default=None,
             help="Poll only the specified patient (by Patient.id). For debugging/backfill.",
+        )
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=None,
+            help="Override the ow.poll_window_days setting for this run. For backfill.",
         )
 
     def handle(self, *args, **options):
@@ -157,6 +169,23 @@ class Command(BaseCommand):
         except ValueError:
             return None
 
+    @staticmethod
+    def _poll_window(options):
+        """How far back to ask OW for samples when a patient has nothing to resume from.
+
+        A patient who links after already wearing a device has no prior Observation,
+        so this window is the only thing deciding whether their history is reachable.
+        Once they have one, the resume watermark is always the later bound, which is
+        why widening this costs nothing on subsequent polls.
+        """
+        days = options.get("days")
+        if days is None:
+            try:
+                days = int(get_setting("ow.poll_window_days", DEFAULT_POLL_WINDOW_DAYS))
+            except (TypeError, ValueError):
+                days = DEFAULT_POLL_WINDOW_DAYS
+        return timedelta(days=max(days, 1))
+
     def _run_poll(self, options):
         mode = str(get_setting("ow.ingest_mode", "normalized") or "normalized").lower()
         if mode not in ("normalized", "raw"):
@@ -179,6 +208,7 @@ class Command(BaseCommand):
             return
 
         oura_ds, _ = DataSource.objects.get_or_create(name="Oura", defaults={"type": "personal_device"})
+        poll_window = self._poll_window(options)
 
         # Only users linked to an OW account: identifier startswith "ow:".
         users = JheUser.objects.filter(identifier__startswith="ow:")
@@ -200,10 +230,10 @@ class Command(BaseCommand):
                 try:
                     if mode == "normalized":
                         created = self._poll_user_normalized(
-                            user, patient, ow_type, code, oura_ds, ow_api_url, ow_api_key
+                            user, patient, ow_type, code, oura_ds, ow_api_url, ow_api_key, poll_window
                         )
                     else:
-                        created = self._poll_user_raw(user, patient, ow_type, code, oura_ds)
+                        created = self._poll_user_raw(user, patient, ow_type, code, oura_ds, poll_window)
                     total_created += created
                 except Exception:
                     logger.exception("ow_poll failed for jhe_user_id=%s type=%s", user.id, ow_type)
@@ -258,10 +288,10 @@ class Command(BaseCommand):
 
         logger.warning("OW timeseries hit MAX_PAGES for user=%s type=%s", user.id, data_type)
 
-    def _poll_user_normalized(self, user, patient, ow_type, code, data_source, ow_api_url, ow_api_key):
+    def _poll_user_normalized(self, user, patient, ow_type, code, data_source, ow_api_url, ow_api_key, poll_window):
         ow_user_id = user.identifier.removeprefix("ow:")
         end_time = timezone.now()
-        start_time = end_time - POLL_WINDOW
+        start_time = end_time - poll_window
 
         # Resume from the most recent successfully ingested record so we
         # don't refetch the entire window every tick.
@@ -324,7 +354,7 @@ class Command(BaseCommand):
         logger.info("Poll completed for jhe_user=%s patient=%s created=%d", user.id, patient.id, created)
         return created
 
-    def _poll_user_raw(self, user, patient, ow_type, code, data_source):
+    def _poll_user_raw(self, user, patient, ow_type, code, data_source, poll_window):
         """Raw S3-backed ingest. Walks the OW MinIO bucket for new objects.
 
         Each individual record (not each S3 object) is deduped via
@@ -337,7 +367,7 @@ class Command(BaseCommand):
 
         ow_user_id = user.identifier.removeprefix("ow:")
         end_time = timezone.now()
-        start_time = end_time - POLL_WINDOW
+        start_time = end_time - poll_window
 
         last_obs = (
             Observation.objects.filter(

--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -260,6 +260,7 @@ class Command(BaseCommand):
             # patient.py / ow_poll.
             ("ow.api_url", "string", "http://localhost:8001"),
             ("ow.api_key", "string", ""),
+            ("ow.poll_window_days", "int", 1),
         ]
         for key, value_type, value in jhe_settings:
             setting, _ = JheSetting.objects.update_or_create(

--- a/tests/backend/test_ow_poll.py
+++ b/tests/backend/test_ow_poll.py
@@ -435,3 +435,52 @@ def test_raw_mode_handles_string_source_field(db, ow_user, patient_with_consent,
         call_command("ow_poll", stdout=StringIO())
 
     assert Observation.objects.filter(subject_patient=patient_with_consent).count() == 1
+
+
+def _requested_start(mock_get):
+    from datetime import datetime
+
+    return datetime.fromisoformat(mock_get.call_args[1]["params"]["start_time"])
+
+
+def test_poll_window_days_setting_widens_the_first_fetch(db, ow_user, patient_with_consent, hr_concept):
+    """A patient linking with existing history has nothing to resume from, so the
+    window alone decides how far back OW is asked to look."""
+    _set_jhe_setting("module.ow", True)
+    _set_jhe_setting("ow.poll_window_days", 30, value_type="int")
+    _clear_sync_lock()
+
+    with patch("core.management.commands.ow_poll.requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"data": [], "pagination": {"has_more": False}}
+        call_command("ow_poll", stdout=StringIO())
+
+    age = timezone.now() - _requested_start(mock_get)
+    assert 29 <= age.days <= 30, f"expected a 30 day window, asked for {age.days}"
+
+
+def test_days_flag_overrides_the_setting(db, ow_user, patient_with_consent, hr_concept):
+    _set_jhe_setting("module.ow", True)
+    _set_jhe_setting("ow.poll_window_days", 30, value_type="int")
+    _clear_sync_lock()
+
+    with patch("core.management.commands.ow_poll.requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"data": [], "pagination": {"has_more": False}}
+        call_command("ow_poll", "--days", "2", stdout=StringIO())
+
+    age = timezone.now() - _requested_start(mock_get)
+    assert 1 <= age.days <= 2, f"expected a 2 day window, asked for {age.days}"
+
+
+def test_poll_window_defaults_to_one_day(db, ow_user, patient_with_consent, hr_concept):
+    _set_jhe_setting("module.ow", True)
+    _clear_sync_lock()
+
+    with patch("core.management.commands.ow_poll.requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"data": [], "pagination": {"has_more": False}}
+        call_command("ow_poll", stdout=StringIO())
+
+    age = timezone.now() - _requested_start(mock_get)
+    assert age.days == 1, f"expected the 1 day default, asked for {age.days}"


### PR DESCRIPTION
Adds ow.poll_window_days (default 1) and a --days override, so a patient who links with existing device history can be backfilled.